### PR TITLE
HARMONY-571: Fix harmony_host_url value in SIT

### DIFF
--- a/test/harmony-regression/HarmonyRegression.ipynb
+++ b/test/harmony-regression/HarmonyRegression.ipynb
@@ -40,7 +40,8 @@
     "# Import libraries used throughout the notebook\n",
     "from notebook_helpers import get, post, show, get_data_urls, show_async, show_async_condensed, show_shape, print_async_status, check_bbox_subset, check_stac\n",
     "import json\n",
-    "import intake"
+    "import intake\n",
+    "import re"
    ]
   },
   {
@@ -60,7 +61,9 @@
    "source": [
     "coverages_root = '{root}/{collection}/ogc-api-coverages/1.0.0/collections/{variable}/coverage/rangeset'\n",
     "\n",
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "is_uat_or_sit = harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov' or re.search(\"http:\\/\\/internal-harmony-.*us-west-2\\.elb.amazonaws\\.com\", harmony_host_url)\n",
+    "\n",
+    "if is_uat_or_sit:\n",
     "    l3_collection = 'C1234088182-EEDTEST'\n",
     "    l3_zarr_collection = 'C1234088182-EEDTEST'\n",
     "    l2_collection = 'C1233860183-EEDTEST'\n",
@@ -93,7 +96,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    #By default, this reformats to tiff\n",
     "    params = {\n",
     "        'subset': [\n",
@@ -119,7 +122,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = get(\n",
     "    coverages_root.format(\n",
     "        root=harmony_host_url,\n",
@@ -147,7 +150,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -179,7 +182,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    #Add 3 requests\n",
     "    response1 = get(coverages_root.format(root=harmony_host_url, collection=l3_collection, variable='all'), params={'format': 'image/tiff', 'maxResults': '20'})\n",
     "    response2 = get(coverages_root.format(root=harmony_host_url, collection=l3_collection, variable='all'), params={'format': 'image/tiff', 'maxResults': '20'})\n",
@@ -235,7 +238,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    show_shape('zip://./notebook_helpers/test_in-polygon.shp.zip')\n",
     "    show(get('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/shapefile_example/shapefile_r_001_249_20090109T000000.shp.zip'))"
    ]
@@ -248,7 +251,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = post(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -369,7 +372,7 @@
    "source": [
     "#Shows original test data for easy visual comparison\n",
     "\n",
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = get('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example_l2/nc/015_02_210_europe.nc')\n",
     "    show(response, example_vars)"
    ]
@@ -389,7 +392,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -409,7 +412,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = get(\n",
     "    coverages_root.format(\n",
     "        root=harmony_host_url,\n",
@@ -441,7 +444,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -491,7 +494,7 @@
     "           'time(\"2012-03-03T12:17:00\":\"2012-03-03T12:18:00\")']\n",
     "        })\n",
     "\n",
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    show(response, ['ssha'])\n",
     "else:\n",
     "    show(response, ['sea_surface_temperature'])"
@@ -526,7 +529,7 @@
     "             'time(\"2012-03-03T00:00:00Z\":\"2012-03-03T02:59:59Z\")'\n",
     "            ]})\n",
     "\n",
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    show_async_condensed(response, ['ssha'])\n",
     "else:\n",
     "    show_async_condensed(response, ['sea_surface_temperature'])"
@@ -555,7 +558,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -583,7 +586,7 @@
    },
    "outputs": [],
    "source": [
-    "if harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov':\n",
+    "if is_uat_or_sit:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",

--- a/test/harmony-regression/HarmonyRegression.ipynb
+++ b/test/harmony-regression/HarmonyRegression.ipynb
@@ -61,9 +61,9 @@
    "source": [
     "coverages_root = '{root}/{collection}/ogc-api-coverages/1.0.0/collections/{variable}/coverage/rangeset'\n",
     "\n",
-    "is_uat_or_sit = harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov' or re.search(\"http:\\/\\/internal-harmony-.*us-west-2\\.elb.amazonaws\\.com\", harmony_host_url)\n",
+    "is_not_prod = harmony_host_url == 'https://harmony.uat.earthdata.nasa.gov' or harmony_host_url == 'https://harmony.sit.earthdata.nasa.gov' or re.search(\"http:\\/\\/internal-harmony-.*us-west-2\\.elb.amazonaws\\.com\", harmony_host_url)\n",
     "\n",
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    l3_collection = 'C1234088182-EEDTEST'\n",
     "    l3_zarr_collection = 'C1234088182-EEDTEST'\n",
     "    l2_collection = 'C1233860183-EEDTEST'\n",
@@ -96,7 +96,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    #By default, this reformats to tiff\n",
     "    params = {\n",
     "        'subset': [\n",
@@ -122,7 +122,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = get(\n",
     "    coverages_root.format(\n",
     "        root=harmony_host_url,\n",
@@ -150,7 +150,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -182,7 +182,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    #Add 3 requests\n",
     "    response1 = get(coverages_root.format(root=harmony_host_url, collection=l3_collection, variable='all'), params={'format': 'image/tiff', 'maxResults': '20'})\n",
     "    response2 = get(coverages_root.format(root=harmony_host_url, collection=l3_collection, variable='all'), params={'format': 'image/tiff', 'maxResults': '20'})\n",
@@ -238,7 +238,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    show_shape('zip://./notebook_helpers/test_in-polygon.shp.zip')\n",
     "    show(get('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/shapefile_example/shapefile_r_001_249_20090109T000000.shp.zip'))"
    ]
@@ -251,7 +251,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = post(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -372,7 +372,7 @@
    "source": [
     "#Shows original test data for easy visual comparison\n",
     "\n",
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = get('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example_l2/nc/015_02_210_europe.nc')\n",
     "    show(response, example_vars)"
    ]
@@ -392,7 +392,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -412,7 +412,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = get(\n",
     "    coverages_root.format(\n",
     "        root=harmony_host_url,\n",
@@ -444,7 +444,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -494,7 +494,7 @@
     "           'time(\"2012-03-03T12:17:00\":\"2012-03-03T12:18:00\")']\n",
     "        })\n",
     "\n",
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    show(response, ['ssha'])\n",
     "else:\n",
     "    show(response, ['sea_surface_temperature'])"
@@ -529,7 +529,7 @@
     "             'time(\"2012-03-03T00:00:00Z\":\"2012-03-03T02:59:59Z\")'\n",
     "            ]})\n",
     "\n",
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    show_async_condensed(response, ['ssha'])\n",
     "else:\n",
     "    show_async_condensed(response, ['sea_surface_temperature'])"
@@ -558,7 +558,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",
@@ -586,7 +586,7 @@
    },
    "outputs": [],
    "source": [
-    "if is_uat_or_sit:\n",
+    "if is_not_prod:\n",
     "    response = get(\n",
     "        coverages_root.format(\n",
     "            root=harmony_host_url,\n",


### PR DESCRIPTION
Fix to allow the notebooks to run in SIT when run from Bamboo by allowing the case where the harmony_host_url variable is set to the internal load balancer instead of the semi-public URL. 