### PR TITLE
HARMONY-778: Temporarily comment out cells using variable subsetter

### DIFF
--- a/test/harmony-regression/HarmonyRegression.ipynb
+++ b/test/harmony-regression/HarmonyRegression.ipynb
@@ -558,17 +558,18 @@
    },
    "outputs": [],
    "source": [
-    "if is_not_prod:\n",
-    "    response = get(\n",
-    "        coverages_root.format(\n",
-    "            root=harmony_host_url,\n",
-    "            collection=var_collection, \n",
-    "            variable='%2Fgt1l%2Fland_segments%2Fcanopy%2Fh_canopy'), \n",
-    "        params={\n",
-    "            'granuleid':'G1238479514-EEDTEST'\n",
-    "        })\n",
+    "# Re-enable this when https://bugs.earthdata.nasa.gov/browse/HYRAX-387 is fixed\n",
+    "# if is_not_prod:\n",
+    "#     response = get(\n",
+    "#         coverages_root.format(\n",
+    "#             root=harmony_host_url,\n",
+    "#             collection=var_collection, \n",
+    "#             variable='%2Fgt1l%2Fland_segments%2Fcanopy%2Fh_canopy'), \n",
+    "#         params={\n",
+    "#             'granuleid':'G1238479514-EEDTEST'\n",
+    "#         })\n",
     "\n",
-    "    show(response, ['/gt1l/land_segments/canopy/h_canopy'])"
+    "#     show(response, ['/gt1l/land_segments/canopy/h_canopy'])"
    ]
   },
   {
@@ -586,15 +587,16 @@
    },
    "outputs": [],
    "source": [
-    "if is_not_prod:\n",
-    "    response = get(\n",
-    "        coverages_root.format(\n",
-    "            root=harmony_host_url,\n",
-    "            collection=var_collection, \n",
-    "            variable='%2Fgt1l%2Fland_segments%2Fcanopy%2Fh_canopy'), \n",
-    "            params={'maxResults': '3'})\n",
+    "# Re-enable this when https://bugs.earthdata.nasa.gov/browse/HYRAX-387 is fixed\n",
+    "# if is_not_prod:\n",
+    "#     response = get(\n",
+    "#         coverages_root.format(\n",
+    "#             root=harmony_host_url,\n",
+    "#             collection=var_collection, \n",
+    "#             variable='%2Fgt1l%2Fland_segments%2Fcanopy%2Fh_canopy'), \n",
+    "#             params={'maxResults': '3'})\n",
     "\n",
-    "    show_async_condensed(response, ['/gt1l/land_segments/canopy/h_canopy'])"
+    "#     show_async_condensed(response, ['/gt1l/land_segments/canopy/h_canopy'])"
    ]
   },
   {


### PR DESCRIPTION
Needed until https://bugs.earthdata.nasa.gov/browse/HYRAX-387 is fixed