### PR TITLE
HARMONY-841: Update SIT to use https://harmony.sit.earthdata.nasa.gov

### DIFF
--- a/script/test.sh
+++ b/script/test.sh
@@ -49,7 +49,10 @@ uat)
 prod)
   harmony_host_url="https://harmony.earthdata.nasa.gov"
   ;;
-sit|sandbox)
+sit)
+  harmony_host_url="https://harmony.sit.earthdata.nasa.gov"
+  ;;
+sandbox)
   harmony_host_url="http://$(get_elb)"
   ;;
 *)


### PR DESCRIPTION
Fix now that we can hit the harmony SIT URL from within the SIT account.