### PR TITLE
DAS-1115 - Activate HOSS-all variable, no bounding box request.

### DIFF
--- a/test/sds/SDS_Regression.ipynb
+++ b/test/sds/SDS_Regression.ipynb
@@ -790,33 +790,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1b060b65-b8a4-4723-a965-7b753c375cc0",
-   "metadata": {},
-   "source": [
-    "### Retrieve original data for visual comparison"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "216c33a0-fae1-4c68-b276-0611ba295844",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if harmony_environment in hoss_env:\n",
-    "    original_file_name, request_success = request(hoss_info['original_data_url'])\n",
-    "    assert request_success, 'Unsuccessful download of HOSS input granule.'\n",
-    "    \n",
-    "    plot_variable(original_file_name, '/atmosphere_cloud_liquid_water_content', '/longitude', '/latitude',\n",
-    "                  title='HOSS input granule.', colourbar_units='Columnar cloud liquid water (kg.m-2)',\n",
-    "                  x_label='Longitude (degrees east)', y_label='Latitude (degrees north)',\n",
-    "                  levels=np.linspace(-0.05, 2.45, 51))\n",
-    "else:\n",
-    "    print(f'The Variable Subsetter is not configured for environment: \"{harmony_environment}\" - skipping download.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "ef9ec4d2-2228-47d0-a990-d5a4d77b7bc7",
    "metadata": {},
    "source": [
@@ -1006,7 +979,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"\n",
     "if harmony_environment in hoss_env:\n",
     "    all_request_url = get_harmony_request_url(harmony_host_url, hoss_info['collection_id'])\n",
     "\n",
@@ -1027,8 +999,7 @@
     "                          '/latitude', '/longitude', '/rainfall_rate', '/sst_dtime', '/time', '/wind_speed']\n",
     "    assert all_variables_present(all_file_name, expected_variables), 'Missing variables in HOSS all-variable output'\n",
     "else:\n",
-    "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')\n",
-    "\"\"\""
+    "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
   },
   {
@@ -1040,7 +1011,7 @@
     "\n",
     "If no variables and no bounding box are specified, the entire original granule should be retrieved. (This will run the Variable Subsetter branch of the `sds/variable-subsetter` Docker image, skipping any spatial subsetting portion of the service)\n",
     "\n",
-    "The plotted image should match the original source data, plotted above as \"HOSS input granule\"."
+    "The plotted image should cover the entire Earth (landmasses will be masked)."
    ]
   },
   {


### PR DESCRIPTION
This PR does two things:

* Activates the HOSS all-variable, no-bounding-box request. This should work now UAT is >= 0.0.389 (currently 0.0.394).
* Removes the download of the HOSS input granule for visual display. When the tests were run for the 0.0.394 UAT release, there was a CloudFront error retrieving the source granule for the HOSS data. I think that's because this granule is hosted by GHRC in their Cumulus instance. The download is non-critical, so I just removed it.