### PR TITLE
DAS-1265 - Add regression tests for SDS Segmented Trajectory Subsetter.

### DIFF
--- a/test/sds/SDS_Regression.ipynb
+++ b/test/sds/SDS_Regression.ipynb
@@ -131,7 +131,12 @@
    "source": [
     "def print_error(error_string: str) -> str:\n",
     "    \"\"\"Print an error, with formatting for red text. \"\"\"\n",
-    "    print(f'\\033[91m{error_string}\\033[0m')"
+    "    print(f'\\033[91m{error_string}\\033[0m')\n",
+    "\n",
+    "\n",
+    "def print_success(success_string: str) -> str:\n",
+    "    \"\"\" Print a success message, with formatting for green text. \"\"\"\n",
+    "    print(f'\\033[92mSuccess: {success_string}\\033[0m')"
    ]
   },
   {
@@ -322,7 +327,16 @@
     "\n",
     "    \"\"\"\n",
     "    with Dataset(file_name, 'r') as dataset:\n",
-    "        return all(variable_in_dataset(dataset, variable) for variable in variable_list)"
+    "        return all(variable_in_dataset(dataset, variable) for variable in variable_list)\n",
+    "\n",
+    "\n",
+    "def variable_values_all_in_range(file_name: str, variable_name: str,\n",
+    "                                  minimum_value: float, maximum_value: float) -> bool:\n",
+    "    \"\"\" Ensure that all values in a specified variable are within a specified range. \"\"\"\n",
+    "    with Dataset(file_name, 'r') as dataset:\n",
+    "        variable_values = dataset[variable_name][:]\n",
+    "\n",
+    "    return variable_values.max() <= maximum_value and variable_values.min() >= minimum_value"
    ]
   },
   {
@@ -458,14 +472,14 @@
    "source": [
     "if harmony_environment in swath_projector_env:\n",
     "    original_file_name, request_success = request(swath_projector_info['original_data_url'])\n",
-    "\n",
-    "    plot_variable(original_file_name, 'alpha_var', 'lon', 'lat', title='Input Africa granule',\n",
-    "                  colourbar_units='Land mask', x_label='Longitude (degrees east)', y_label='Latitude (degrees north)')\n",
     "    \n",
     "    assert request_success, 'Unsuccessful download of Swath Projector source data.'\n",
     "    \n",
     "    expected_variables = ['/lat', '/lon', '/time', '/alpha_var', '/blue_var', '/green_var', '/red_var']\n",
     "    assert all_variables_present(original_file_name, expected_variables), 'Missing variables in downloaded output'\n",
+    "\n",
+    "    plot_variable(original_file_name, 'alpha_var', 'lon', 'lat', title='Input Africa granule',\n",
+    "                  colourbar_units='Land mask', x_label='Longitude (degrees east)', y_label='Latitude (degrees north)')\n",
     "else:\n",
     "    print(f'The Swath Projector is not configured for environment: \"{harmony_environment}\" - skipping download.')"
    ]
@@ -491,13 +505,15 @@
     "    defaults_file_name, defaults_success = request(swath_projector_request_url,\n",
     "                                                   request_parameters={'granuleId': swath_projector_info['granule_id']})\n",
     "\n",
-    "    plot_variable(defaults_file_name, 'alpha_var', 'lon', 'lat', title='Default parameters Africa granule',\n",
-    "                  colourbar_units='Land mask', x_label='Longitude (degrees east)', y_label='Latitude (degrees north)')\n",
-    "    \n",
     "    assert defaults_success, 'Unsuccessful Swath Projector default request'\n",
     "    \n",
     "    expected_variables = ['/lat', '/lon', '/latitude_longitude', '/time', '/alpha_var', '/blue_var', '/green_var', '/red_var']\n",
     "    assert all_variables_present(defaults_file_name, expected_variables), 'Missing variables in downloaded output'\n",
+    "\n",
+    "    plot_variable(defaults_file_name, 'alpha_var', 'lon', 'lat', title='Default parameters Africa granule',\n",
+    "                  colourbar_units='Land mask', x_label='Longitude (degrees east)', y_label='Latitude (degrees north)')\n",
+    "\n",
+    "    print_success('Swath projector with default parameters.')\n",
     "else:\n",
     "    print(f'The Swath Projector is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -527,14 +543,16 @@
     "                            'scaleExtent': '42,-27,52,-10', # W, S, E, N\n",
     "                            'subset': 'time(\"2020-01-15T00:00:00Z\":\"2020-01-16T00:00:00Z\")'}\n",
     "    )\n",
+    "    \n",
+    "    assert epsg_success, 'Unsuccessful Swath Projector EPSG code request.'\n",
+    "\n",
+    "    expected_variables = ['/lat', '/lon', '/latitude_longitude', '/time', '/alpha_var', '/blue_var', '/green_var', '/red_var']\n",
+    "    assert all_variables_present(epsg_file_name, expected_variables), 'Missing variables in downloaded output'\n",
     "\n",
     "    plot_variable(epsg_file_name, 'alpha_var', 'lon', 'lat', title='EPSG:4326 output Africa granule',\n",
     "                  colourbar_units='Land mask', x_label='Longitude (degrees east)', y_label='Latitude (degrees north)')\n",
-    "    \n",
-    "    assert epsg_success, 'Unsuccessful Swath Projector EPSG code request.'\n",
-    "    \n",
-    "    expected_variables = ['/lat', '/lon', '/latitude_longitude', '/time', '/alpha_var', '/blue_var', '/green_var', '/red_var']\n",
-    "    assert all_variables_present(epsg_file_name, expected_variables), 'Missing variables in downloaded output'\n",
+    "\n",
+    "    print_success('Swath Projector EPSG code request.')\n",
     "else:\n",
     "    print(f'The Swath Projector is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -565,13 +583,15 @@
     "                            'granuleId': swath_projector_info['granule_id']}\n",
     "    )\n",
     "\n",
+    "    assert proj4_string_success, 'Unsuccessful Swath Projector interpolation and Proj4 request.'\n",
+    "\n",
+    "    expected_variables = ['/x', '/y', '/lambert_conformal_conic', '/time', '/alpha_var', '/blue_var', '/green_var', '/red_var']\n",
+    "    assert all_variables_present(proj4_string_file_name, expected_variables), 'Missing variables in downloaded output'\n",
+    "\n",
     "    plot_variable(proj4_string_file_name, 'alpha_var', 'x', 'y', title='Lambert Conformal Conic CRS, Africa granule',\n",
     "                  colourbar_units='Land mask', x_label='Longitude (degrees east)', y_label='Latitude (degrees north)')\n",
     "\n",
-    "    assert proj4_string_success, 'Unsuccessful Swath Projector interpolation and Proj4 request.'\n",
-    "    \n",
-    "    expected_variables = ['/x', '/y', '/lambert_conformal_conic', '/time', '/alpha_var', '/blue_var', '/green_var', '/red_var']\n",
-    "    assert all_variables_present(proj4_string_file_name, expected_variables), 'Missing variables in downloaded output'\n",
+    "    print_success('Swath Projector interpolation and Proj4 request')\n",
     "else:\n",
     "    print(f'The Swath Projector is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -598,13 +618,15 @@
     "                            'granuleId': swath_projector_info['granule_id']}\n",
     "    )\n",
     "\n",
-    "    plot_variable(async_file_name, 'alpha_var', 'lon', 'lat', title='Scale extents output Africa granule',\n",
-    "                  colourbar_units='Land mask', x_label='Longitude (degrees east)', y_label='Latitude (degrees north)')\n",
-    "\n",
     "    assert async_success, 'Unsuccessful Swath Projector asynchronous request'\n",
     "\n",
     "    expected_variables = ['/lat', '/lon', '/latitude_longitude', '/time', '/alpha_var', '/blue_var', '/green_var', '/red_var']\n",
     "    assert all_variables_present(async_file_name, expected_variables), 'Missing variables in downloaded output'\n",
+    "\n",
+    "    plot_variable(async_file_name, 'alpha_var', 'lon', 'lat', title='Scale extents output Africa granule',\n",
+    "                  colourbar_units='Land mask', x_label='Longitude (degrees east)', y_label='Latitude (degrees north)')\n",
+    "\n",
+    "    print_success('Swath Projector asynchronous request.')\n",
     "else:\n",
     "    print(f'The Swath Projector is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -673,6 +695,8 @@
     "                          '/gt1l/land_segments/latitude', '/gt1l/land_segments/longitude']\n",
     "    \n",
     "    assert all_variables_present(sync_file_name, expected_variables), 'Missing variables in downloaded output'\n",
+    "\n",
+    "    print_success('Variable subsetter synchronous request.')\n",
     "else:\n",
     "    print(f'The Variable Subsetter is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -719,6 +743,8 @@
     "                          '/gt1l/land_segments/longitude']\n",
     "    \n",
     "    assert all_variables_present(async_file_name, expected_variables), 'Missing variables in downloaded output'\n",
+    "\n",
+    "    print_success('Variable Subsetter asynchronous request.')\n",
     "else:\n",
     "    print(f'The Variable Subsetter is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -755,6 +781,8 @@
     "    assert all_success, 'Unsuccessful Variable Subsetter request, all variables'\n",
     "\n",
     "    # Recursive check of all variables and groups from input granule.\n",
+    "\n",
+    "    print_success('Variable Subsetter all variable request.')\n",
     "else:\n",
     "    print(f'The Variable Subsetter is not configured for environment: \"{harmony_environment}\" - skipping test.')\n",
     "\"\"\""
@@ -767,7 +795,7 @@
    "source": [
     "## Harmony OPeNDAP SubSetter (HOSS):\n",
     "\n",
-    "HOSS is currently only activated for collections in UAT. Requests will be made against the GHRC RSSMIF16D collection."
+    "HOSS is currently deployed to Sandbox, SIT, UAT and production. However, it is only associated with collections in UAT. Requests will be made against the GHRC RSSMIF16D collection."
    ]
   },
   {
@@ -795,7 +823,7 @@
    "source": [
     "### HOSS synchronous request\n",
     "\n",
-    "This is a request the exercises the full range of HOSS options: bounding box and variable subsetting.\n",
+    "This is a request that exercises the full range of HOSS options: bounding box and variable subsetting.\n",
     "\n",
     "Requested parameter:\n",
     "\n",
@@ -827,13 +855,15 @@
     "\n",
     "    assert sync_success, 'Unsuccessful HOSS synchronous request.'\n",
     "\n",
+    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/latitude', '/longitude', '/time']\n",
+    "    assert all_variables_present(sync_file_name, expected_variables), 'Missing variables in HOSS synchronous output'\n",
+    "\n",
     "    plot_variable(sync_file_name, '/atmosphere_cloud_liquid_water_content', '/longitude', '/latitude',\n",
     "                  title='HOSS synchronous results.', colourbar_units='Columnar cloud liquid water (kg.m-2)',\n",
     "                  x_label='Longitude (degrees east)', y_label='Latitude (degrees north)',\n",
     "                  levels=np.linspace(-0.05, 2.45, 51))\n",
     "\n",
-    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/latitude', '/longitude', '/time']\n",
-    "    assert all_variables_present(sync_file_name, expected_variables), 'Missing variables in HOSS synchronous output'\n",
+    "    print_success('HOSS synchronous request.')\n",
     "else:\n",
     "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -867,13 +897,15 @@
     "\n",
     "    assert async_success, 'Unsuccessful HOSS asynchronous request.'\n",
     "\n",
+    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/latitude', '/longitude', '/time']\n",
+    "    assert all_variables_present(async_file_name, expected_variables), 'Missing variables in HOSS asynchronous output'\n",
+    "\n",
     "    plot_variable(async_file_name, '/atmosphere_cloud_liquid_water_content', '/longitude', '/latitude',\n",
     "                  title='HOSS asynchronous results.', colourbar_units='Columnar cloud liquid water (kg.m-2)',\n",
     "                  x_label='Longitude (degrees east)', y_label='Latitude (degrees north)',\n",
     "                  levels=np.linspace(-0.05, 2.45, 51))\n",
     "\n",
-    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/latitude', '/longitude', '/time']\n",
-    "    assert all_variables_present(async_file_name, expected_variables), 'Missing variables in HOSS asynchronous output'\n",
+    "    print_success('HOSS asynchronous request.')\n",
     "else:\n",
     "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -909,13 +941,15 @@
     "\n",
     "    assert grid_edge_success, 'Unsuccessful HOSS request crossing longitudinal edge.'\n",
     "\n",
+    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/latitude', '/longitude', '/time']\n",
+    "    assert all_variables_present(grid_edge_file_name, expected_variables), 'Missing variables in grid-edge-crossing output'\n",
+    "\n",
     "    plot_variable(grid_edge_file_name, '/atmosphere_cloud_liquid_water_content', '/longitude', '/latitude',\n",
     "                  title='HOSS request crossing grid edge.', colourbar_units='Columnar cloud liquid water (kg.m-2)',\n",
     "                  x_label='Longitude (degrees east)', y_label='Latitude (degrees north)',\n",
     "                  levels=np.linspace(-0.05, 2.45, 51))\n",
     "\n",
-    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/latitude', '/longitude', '/time']\n",
-    "    assert all_variables_present(grid_edge_file_name, expected_variables), 'Missing variables in grid-edge-crossing output'\n",
+    "    print_success('HOSS request crossing longitudinal edge.')\n",
     "else:\n",
     "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -949,13 +983,15 @@
     "\n",
     "    assert no_bbox_success, 'Unsuccessful HOSS request without bounding box.'\n",
     "\n",
+    "    expected_variables = ['/sst_dtime', '/wind_speed', '/latitude', '/longitude', '/time']\n",
+    "    assert all_variables_present(no_bbox_file_name, expected_variables), 'Missing variables in no bounding box output'\n",
+    "\n",
     "    plot_variable(no_bbox_file_name, '/wind_speed', '/longitude', '/latitude',\n",
     "                  title='HOSS request no bounding box.', colourbar_units='Wind speed (m/s)',\n",
     "                  x_label='Longitude (degrees east)', y_label='Latitude (degrees north)',\n",
     "                  levels=np.linspace(0, 50, 51))\n",
     "\n",
-    "    expected_variables = ['/sst_dtime', '/wind_speed', '/latitude', '/longitude', '/time']\n",
-    "    assert all_variables_present(no_bbox_file_name, expected_variables), 'Missing variables in no bounding box output'\n",
+    "    print_success('HOSS request without bounding box.')\n",
     "else:\n",
     "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -967,9 +1003,7 @@
    "source": [
     "### HOSS request all variables\n",
     "\n",
-    "If there are no variables specified, HOSS should retrieve all variables. If the bounding box is specified, all gridded variables should still be constrained to the requested spatial region.\n",
-    "\n",
-    "**This regression test cannot be deployed until Harmony v0.0.389 is deployed to UAT.**"
+    "If there are no variables specified, HOSS should retrieve all variables. If the bounding box is specified, all gridded variables should still be constrained to the requested spatial region."
    ]
   },
   {
@@ -990,14 +1024,16 @@
     "\n",
     "    assert all_success, 'Unsuccessful HOSS all-variable request.'\n",
     "\n",
+    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/atmosphere_water_vapor_content',\n",
+    "                          '/latitude', '/longitude', '/rainfall_rate', '/sst_dtime', '/time', '/wind_speed']\n",
+    "    assert all_variables_present(all_file_name, expected_variables), 'Missing variables in HOSS all-variable output'\n",
+    "\n",
     "    plot_variable(all_file_name, '/atmosphere_cloud_liquid_water_content', '/longitude', '/latitude',\n",
     "                  title='HOSS all variable results.', colourbar_units='Columnar cloud liquid water (kg.m-2)',\n",
     "                  x_label='Longitude (degrees east)', y_label='Latitude (degrees north)',\n",
     "                  levels=np.linspace(-0.05, 2.45, 51))\n",
     "\n",
-    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/atmosphere_water_vapor_content',\n",
-    "                          '/latitude', '/longitude', '/rainfall_rate', '/sst_dtime', '/time', '/wind_speed']\n",
-    "    assert all_variables_present(all_file_name, expected_variables), 'Missing variables in HOSS all-variable output'\n",
+    "    print_success('HOSS all-variable request.')\n",
     "else:\n",
     "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -1031,15 +1067,17 @@
     "\n",
     "    assert all_no_bbox_success, 'Unsuccessful HOSS all-variable, no bounding box request.'\n",
     "\n",
+    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/atmosphere_water_vapor_content',\n",
+    "                          '/latitude', '/longitude', '/rainfall_rate', '/sst_dtime', '/time', '/wind_speed']\n",
+    "    assert all_variables_present(all_no_bbox_file_name, expected_variables), 'Missing variables in HOSS all-variable, no bbox output'\n",
+    "\n",
     "    plot_variable(all_no_bbox_file_name, '/atmosphere_cloud_liquid_water_content', '/longitude', '/latitude',\n",
     "                  title='HOSS all variables, no bounding box results.',\n",
     "                  colourbar_units='Columnar cloud liquid water (kg.m-2)',\n",
     "                  x_label='Longitude (degrees east)', y_label='Latitude (degrees north)',\n",
     "                  levels=np.linspace(-0.05, 2.45, 51))\n",
     "\n",
-    "    expected_variables = ['/atmosphere_cloud_liquid_water_content', '/atmosphere_water_vapor_content',\n",
-    "                          '/latitude', '/longitude', '/rainfall_rate', '/sst_dtime', '/time', '/wind_speed']\n",
-    "    assert all_variables_present(all_no_bbox_file_name, expected_variables), 'Missing variables in HOSS all-variable, no bbox output'\n",
+    "    print_success('HOSS all-variable, no bounding box request.')\n",
     "else:\n",
     "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -1102,6 +1140,8 @@
     "                  colourbar_units='Gross Primary Productivity ($\\mathrm{g.cm}^{-2}.\\mathrm{day}^{-1}$)',\n",
     "                  x_label='EASE-2 grid x coordinate (m)', y_label='EASE-2 grid y coordinate (m)',\n",
     "                  levels=np.linspace(0, 30, 31))\n",
+    "\n",
+    "    print_success('MaskFill synchronous request.')\n",
     "else:\n",
     "    print(f'MaskFill is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
@@ -1138,8 +1178,239 @@
     "                  colourbar_units='Gross Primary Productivity ($\\mathrm{g.cm}^{-2}.\\mathrm{day}^{-1}$)',\n",
     "                  x_label='EASE-2 grid x coordinate (m)', y_label='EASE-2 grid y coordinate (m)',\n",
     "                  levels=np.linspace(0, 30, 31))\n",
+    "\n",
+    "    print_success('MaskFill asynchronous request.')\n",
     "else:\n",
     "    print(f'MaskFill is not configured for environment: \"{harmony_environment}\" - skipping test.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "703c863b",
+   "metadata": {},
+   "source": [
+    "## Segmented Trajectory Subsetter:\n",
+    "\n",
+    "The Segmented Trajectory Subsetter is currently only activated for collections in the UAT environment. Requests will be made against granules in the GEDI L4A collection, as this is the only currently active collection. To minimize the size of the output, all requests will use a variable subset - the original granules are > 1 GB in size!\n",
+    "\n",
+    "The specific granule used in the requests below was selected to have a trajectory that crosses the Amazon river basin GeoJSON shape used in the MaskFill regression tests above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68b09818",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trajectory_subsetter_env = {'uat': {'collection_id': 'C1242267295-EEDTEST',\n",
+    "                                    'bounding_box': [-74, -34, -35, 5],  # W, S, E, N (approximately encompassing Brazil)\n",
+    "                                    'granule_id': 'G1242274836-EEDTEST',\n",
+    "                                    'variables': ['%2FBEAM0000%2Fagbd', '%2FBEAM0000%2Fdelta_time',\n",
+    "                                                  '%2FBEAM0000%2Flat_lowestmode', '%2FBEAM0000%2Flon_lowestmode'],\n",
+    "                                    'expected_variables': ['/BEAM0000/agbd', '/BEAM0000/delta_time',\n",
+    "                                                           '/BEAM0000/lat_lowestmode', '/BEAM0000/lon_lowestmode'],\n",
+    "                                    'bbox_subset_param': ['lat(-34:5)', 'lon(-74:-35)'],\n",
+    "                                    'temporal_subset_param': ['time(\"2020-07-08T01:00:00\":\"2020-07-08T02:00:00\")'],\n",
+    "                                    'shape_file_path': 'amazon_basin.geo.json',\n",
+    "                                    'shape_file_bbox': [-80, -19, -44, 9]}}  # Approximate bounding box of Amazon river basin\n",
+    "\n",
+    "if harmony_environment in trajectory_subsetter_env:\n",
+    "    trajectory_subsetter_info = trajectory_subsetter_env[harmony_environment]\n",
+    "    trajectory_subsetter_request_url = get_harmony_request_url(harmony_host_url,\n",
+    "                                                               trajectory_subsetter_info['collection_id'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9f35c7e",
+   "metadata": {},
+   "source": [
+    "### Trajectory Subsetter variable subset request:\n",
+    "\n",
+    "This is a request to retrieve a variable subset of a GEDI L4A granule. The four expected output variables are:\n",
+    "\n",
+    "* `/BEAM0000/agbd` (above ground biomass density)\n",
+    "* `/BEAM0000/delta_time`\n",
+    "* `/BEAM0000/lat_lowestmode`\n",
+    "* `/BEAM0000/lon_lowestmode`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74bf1567",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if harmony_environment in trajectory_subsetter_env:\n",
+    "    ts_variable_request_url = get_harmony_request_url(\n",
+    "        harmony_host_url, trajectory_subsetter_info['collection_id'],\n",
+    "        trajectory_subsetter_info['variables']\n",
+    "    )\n",
+    "\n",
+    "    ts_variable_file_name, ts_variable_success = request(\n",
+    "        ts_variable_request_url,\n",
+    "        request_parameters={'granuleId': trajectory_subsetter_info['granule_id']}\n",
+    "    )\n",
+    "\n",
+    "    assert ts_variable_success, 'Unsuccessful Trajectory Subsetter variable subset request.'\n",
+    "    assert all_variables_present(\n",
+    "        ts_variable_file_name, trajectory_subsetter_info['expected_variables']\n",
+    "    ), 'Missing variables in Trajectory Subsetter output'\n",
+    "\n",
+    "    print_success('Trajectory Subsetter variable subset request.')\n",
+    "else:\n",
+    "    print(f'Trajectory Subsetter is not configured for environment: \"{harmony_environment}\" - skipping test.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42e85030",
+   "metadata": {},
+   "source": [
+    "### Trajectory Subsetter temporal subset request:\n",
+    "\n",
+    "This request will combine a variable subset with a temporal range - as defined via the `subset` request parameter. The requested data should fall between 1am and 2am on the 8th of July 2020."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c51eb82c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if harmony_environment in trajectory_subsetter_env:\n",
+    "    ts_temporal_request_url = get_harmony_request_url(\n",
+    "        harmony_host_url, trajectory_subsetter_info['collection_id'],\n",
+    "        trajectory_subsetter_info['variables']\n",
+    "    )\n",
+    "\n",
+    "    ts_temporal_file_name, ts_temporal_success = request_async(\n",
+    "        ts_temporal_request_url,\n",
+    "        request_parameters={'granuleId': trajectory_subsetter_info['granule_id'],\n",
+    "                            'subset': trajectory_subsetter_info['temporal_subset_param']}\n",
+    "    )\n",
+    "\n",
+    "    assert ts_temporal_success, 'Unsuccessful Trajectory Subsetter temporal subset request.'\n",
+    "    assert all_variables_present(\n",
+    "        ts_temporal_file_name, trajectory_subsetter_info['expected_variables']\n",
+    "    ), 'Missing variables in temporal subset Trajectory Subsetter output'\n",
+    "\n",
+    "    print_success('Trajectory Subsetter temporal subset request.')\n",
+    "else:\n",
+    "    print(f'Trajectory Subsetter is not configured for environment: \"{harmony_environment}\" - skipping test.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f6a86b6",
+   "metadata": {},
+   "source": [
+    "### Trajectory Subsetter bounding box spatial subset request:\n",
+    "\n",
+    "This request combines the variable subset (for output size purposes) with a bounding box spatial subset. The bounding box has been selected to approximately encompass Brazil:\n",
+    "\n",
+    "* -74 ≤ longitude (degrees east) ≤ -35\n",
+    "* -34 ≤ latitude (degress north) ≤ 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ffb9742c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if harmony_environment in trajectory_subsetter_env:\n",
+    "    ts_bbox_request_url = get_harmony_request_url(\n",
+    "        harmony_host_url, trajectory_subsetter_info['collection_id'],\n",
+    "        trajectory_subsetter_info['variables']\n",
+    "    )\n",
+    "\n",
+    "    ts_bbox_file_name, ts_bbox_success = request_async(\n",
+    "        ts_bbox_request_url,\n",
+    "        request_parameters={'granuleId': trajectory_subsetter_info['granule_id'],\n",
+    "                            'subset': trajectory_subsetter_info['bbox_subset_param']}\n",
+    "    )\n",
+    "\n",
+    "    assert ts_bbox_success, 'Unsuccessful Trajectory Subsetter bounding box subset request.'\n",
+    "    assert all_variables_present(\n",
+    "        ts_bbox_file_name, trajectory_subsetter_info['expected_variables']\n",
+    "    ), 'Missing variables in bounding box spatial subset Trajectory Subsetter output'\n",
+    "    assert variable_values_all_in_range(\n",
+    "        ts_bbox_file_name, '/BEAM0000/lon_lowestmode', trajectory_subsetter_info['bounding_box'][0],\n",
+    "        trajectory_subsetter_info['bounding_box'][2]\n",
+    "    ), 'Longitude values not all in expected range, Trajectory Subsetter bounding box request'\n",
+    "    assert variable_values_all_in_range(\n",
+    "        ts_bbox_file_name, '/BEAM0000/lat_lowestmode', trajectory_subsetter_info['bounding_box'][1],\n",
+    "        trajectory_subsetter_info['bounding_box'][3]\n",
+    "    ), 'Latitude values not all in expected range, Trajectory Subsetter bounding box request'\n",
+    "\n",
+    "    print_success('Trajectory Subsetter bounding box spatial subset request.')\n",
+    "else:\n",
+    "    print(f'Trajectory Subsetter is not configured for environment: \"{harmony_environment}\" - skipping test.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05201125",
+   "metadata": {},
+   "source": [
+    "### Trajectory Subsetter polygon spatial subset request:\n",
+    "\n",
+    "The request below combines a variable subset with the Amazon river basin polygon. The output should constrained to be extent of this polygon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a10d6af4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if harmony_environment in maskfill_env:\n",
+    "    ts_polygon_request_url = get_harmony_request_url(\n",
+    "        harmony_host_url, trajectory_subsetter_info['collection_id'],\n",
+    "        trajectory_subsetter_info['variables']\n",
+    "    )\n",
+    "\n",
+    "    ts_polygon_file_name, ts_polygon_success = request_async(\n",
+    "        ts_polygon_request_url,\n",
+    "        request_parameters={'granuleId': trajectory_subsetter_info['granule_id'],\n",
+    "                            'subset': trajectory_subsetter_info['bbox_subset_param']},\n",
+    "        files={'shapefile': (trajectory_subsetter_info['shape_file_path'],\n",
+    "                             open(trajectory_subsetter_info['shape_file_path'], 'r'),\n",
+    "                             'application/geo+json')}\n",
+    "    )\n",
+    "\n",
+    "    assert ts_polygon_success, 'Unsuccessful Trajectory Subsetter polygon spatial subset request.'\n",
+    "    assert all_variables_present(\n",
+    "        ts_polygon_file_name, trajectory_subsetter_info['expected_variables']\n",
+    "    ), 'Missing variables in polygon spatial subset Trajectory Subsetter output'\n",
+    "    assert variable_values_all_in_range(\n",
+    "        ts_polygon_file_name, '/BEAM0000/lon_lowestmode', trajectory_subsetter_info['shape_file_bbox'][0],\n",
+    "        trajectory_subsetter_info['shape_file_bbox'][2]\n",
+    "    ), 'Longitude values not all in expected range, Trajectory Subsetter polygon request'\n",
+    "    assert variable_values_all_in_range(\n",
+    "        ts_polygon_file_name, '/BEAM0000/lat_lowestmode', trajectory_subsetter_info['shape_file_bbox'][1],\n",
+    "        trajectory_subsetter_info['shape_file_bbox'][3]\n",
+    "    ), 'Latitude values not all in expected range, Trajectory Subsetter polygon request'\n",
+    "\n",
+    "    print_success('Trajectory Subsetter polygon spatial subset request.')\n",
+    "else:\n",
+    "    print(f'Trajectory Subsetter is not configured for environment: \"{harmony_environment}\" - skipping test.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da258874",
+   "metadata": {},
+   "source": [
+    "### Segmented Trajectory Subsetter additional tests:\n",
+    "\n",
+    "Ideally, we should test that photon segment indices are correctly handled (e.g., they are all consecutive integers, even if a middle segment is excluded by a subset: [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, ...]). Currently (2021-12-02), there are no Cloud-hosted collections with photon segment indices associated with the Segmented Trajectory Subsetter."
    ]
   },
   {


### PR DESCRIPTION
This PR mainly adds regression tests for the new Segmented Trajectory Subsetter service, including:

* A variable subset.
* A temporal subset.
* A bounding box spatial subset.
* A polygon spatial subset.

In addition:

* Some tests have their assertions moved prior to plotting outputs (such as establishing all expected variables are present), so that the failure is on the assertion, not on a bad attempt to plot data.
* I've added green output text to make it clearer that a cell succeeded, particularly in the case where a test doesn't produce a plot.