### PR TITLE
DAS-1384: Rename of ASF GDAL subsetter to harmony-gdal-adapter.

### DIFF
--- a/test/harmony/Harmony.ipynb
+++ b/test/harmony/Harmony.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "@pytest.mark.parametrize('service_name', [\n",
     "    'harmony/service-example', \n",
-    "    'asfdataservices/gdal-subsetter', \n",
+    "    'nasa/harmony-gdal-adapter', \n",
     "    'podaac/l2-subsetter'\n",
     "])\n",
     "def test_services_are_configured_in_harmony(service_name: str):\n",


### PR DESCRIPTION
I noticed our regression tests were failing. The cause was the change of the name of the ASF GDAL subsetter service to the harmony-gdal-adapter service.