### PR TITLE
fixes docker run command,  now report actual result of container exit code

### DIFF
--- a/test/run_notebooks.sh
+++ b/test/run_notebooks.sh
@@ -12,7 +12,7 @@ images=(harmony harmony-regression sds hga)
 # launch all the docker containers and store their process IDs
 for image in ${images[@]}; do
   echo -e "Test suite ${image} starting"
-  PIDS+=(${image},$(docker run -d --rm -v ${PWD}/output:/root/output -v ${PWD}/${image}:/root/${image} --env harmony_host_url="${HARMONY_HOST_URL}" "harmony/regression-tests-${image}:latest"))
+  PIDS+=(${image},$(docker run -d -v ${PWD}/output:/root/output -v ${PWD}/${image}:/root/${image} --env harmony_host_url="${HARMONY_HOST_URL}" "harmony/regression-tests-${image}:latest"))
 done
 
 trap ctrl_c SIGINT SIGTERM
@@ -45,6 +45,7 @@ for name_comma_pid in ${PIDS[@]}; do
   else
     echo -e "${GREEN}Test suite ${name} succeeded${NC}"
   fi
+  docker rm ${pid} >/dev/null
 done
 
 if [[ ${exit_code} -ne 0 ]]; then


### PR DESCRIPTION
When we changed the docker run command to remove the container on exit with the
`--rm` flag, we inadvertently stopped the script from fetching the container
exit code and we were always reporting success.

This change reverts the docker run to keep the container and we remove the
container explicitly after fetching the result.

# verification steps

I adding a cell to the HGA_regression.ipynb that says

`assert true == false, "this test designed to fail"
`

Next I built and ran the hga tests, I saw that the tests reported a success even though they shouldn't.

```
papermill.exceptions.PapermillExecutionError:
---------------------------------------------------------------------------
Exception encountered at "In [5]":
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Input In [5], in <cell line: 1>()
----> 1 assert true == false, "this test designed to fail"

NameError: name 'true' is not defined

Error response from daemon: No such container: f747ca213cf9178d417b62843ad449da29b35881bfa959530ac76cf2756fe37e
Test suite hga succeeded
Tests completed (passed)
```

I applied these changes to `run-notebooks.sh` and re-ran the tests to show they now fail correctly.

```
Input In [5], in <cell line: 1>()
----> 1 assert true == false, "this test designed to fail"

NameError: name 'true' is not defined

Test suite hga failed with exit code 1
Tests completed (failed)
```

I verified that after both a successful and failed run of the `run-notebooks.sh`, no exited containers remained and status were reported correctly.

