### PR TITLE
Adds regression to test incompatible variables.

### DIFF
--- a/test/hga/HGA_Regression.ipynb
+++ b/test/hga/HGA_Regression.ipynb
@@ -49,7 +49,7 @@
     "from harmony import BBox, Client, Collection, Environment, Request\n",
     "\n",
     "from test_utilities import (check_request_output, clean_test_artefacts,\n",
-    "                            make_request_and_download_result)"
+    "                            make_request_and_download_result, print_success)"
    ]
   },
   {
@@ -1458,13 +1458,7 @@
    "source": [
     "### Sentinel test case 13:\n",
     "\n",
-    "This test requests a bounding box spatial subset while not specifying any variable subset, so all variables should be returned. The output from this test should be identical to Sentinel test case 7.\n",
-    "\n",
-    "The input NetCDF-4 file contains many variables (in a hierarchical structure). The output is expected to have one band per requested variable, alongside coordinate variables. This leads to 7 total output variables (`amplitude`, `coherence`, `connectedComponents` and `unwrappedPhase`, `latitude`, `longitude` and `CRS`).\n",
-    "\n",
-    "# TO FIX: The request completes successfully, but doesn't create an entry in the output STAC.\n",
-    "\n",
-    "**Also, there is a danger the same issue as GeoTIFF \"all\" requests exists - that only the first band is copied to the output.**"
+    "This test requests a bounding box spatial subset while not specifying any variable subset, so all variables should be returned. The Sentinel data has 7 variables with two different sets of grid sizes.  This leads to a request that cannot be fulfilled by HGA and an exception should be raised.\n"
    ]
   },
   {
@@ -1474,47 +1468,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"\n",
+    "import re\n",
+    "\n",
     "if environment_information is not None:\n",
     "    granules = {Environment.PROD: 'G1715962900-ASF',\n",
     "                Environment.UAT: 'G1244144618-EEDTEST',\n",
     "                Environment.SIT: 'G1244144618-EEDTEST'}\n",
     "\n",
-    "    sentinel_directory_thirteen = 'sentinel_test_thirteen'\n",
-    "\n",
     "    sentinel_request_thirteen = Request(collection=environment_information['sentinel_collection'],\n",
     "                                        spatial=BBox(-115.45, 32.95, -115.15, 33.09),\n",
     "                                        granule_id=granules[environment_information['env']])\n",
     "\n",
-    "    sentinel_output_thirteen = make_request_and_download_result(harmony_client, sentinel_request_thirteen,\n",
-    "                                                                sentinel_directory_thirteen)\n",
-    "\n",
-    "    sentinel_variables_thirteen = {'amplitude',\n",
-    "                                   'coherence',\n",
-    "                                   'connectedComponents',\n",
-    "                                   'unwrappedPhase',\n",
-    "                                   'lat',\n",
-    "                                   'lon',\n",
-    "                                   'latitude_longitude'}\n",
-    "\n",
-    "    expected_sentinel_results_thirteen = {'authority': None,\n",
-    "                                          'cs': None,\n",
-    "                                         'gcs': None,\n",
-    "                                         'gcs_epsg': None,\n",
-    "                                         'n_bands': 7,\n",
-    "                                         'proj_cs': None,\n",
-    "                                         'proj_epsg': None,\n",
-    "                                         'reference_image': 'reference_images/sentinel_reference_seven.nc',  # Should be same output as test case 7.\n",
-    "                                         'spatial_extent': [32.95, 33.09, -115.45, -115.15],\n",
-    "                                         'variables': sentinel_variables_thirteen,\n",
-    "                                         'width': 360,\n",
-    "                                         'height': 168}\n",
-    "    \n",
-    "    check_request_output(sentinel_output_thirteen[0], expected_sentinel_results_thirteen)\n",
-    "    clean_test_artefacts(sentinel_directory_thirteen)\n",
+    "    sentinel_job_id_thirteen = harmony_client.submit(sentinel_request_thirteen)\n",
+    "    try: \n",
+    "        harmony_client.wait_for_processing(sentinel_job_id_thirteen, show_progress=True)\n",
+    "    except Exception as exception:\n",
+    "        assert re.search(\"Request cannot be completed: datasets are incompatible and cannot be combined.\", str(exception)), 'Exception not raised correctly'\n",
+    "    print_success('Test raised expected Exception')\n",
     "else:\n",
-    "    print('Skipping test: HGA regression tests not configured for this environment.')\n",
-    "\"\"\""
+    "    print('Skipping test: HGA regression tests not configured for this environment.')\n"
    ]
   },
   {

--- a/test/hga/HGA_Regression.ipynb
+++ b/test/hga/HGA_Regression.ipynb
@@ -1468,8 +1468,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import re\n",
-    "\n",
     "if environment_information is not None:\n",
     "    granules = {Environment.PROD: 'G1715962900-ASF',\n",
     "                Environment.UAT: 'G1244144618-EEDTEST',\n",
@@ -1483,7 +1481,7 @@
     "    try: \n",
     "        harmony_client.wait_for_processing(sentinel_job_id_thirteen, show_progress=True)\n",
     "    except Exception as exception:\n",
-    "        assert re.search(\"Request cannot be completed: datasets are incompatible and cannot be combined.\", str(exception)), 'Exception not raised correctly'\n",
+    "        assert \"Request cannot be completed: datasets are incompatible and cannot be combined.\" in str(exception), 'Exception not raised correctly'\n",
     "    print_success('Test raised expected Exception')\n",
     "else:\n",
     "    print('Skipping test: HGA regression tests not configured for this environment.')\n"


### PR DESCRIPTION
Sentinel 1 has varaibles of different grid sizes and cannot be combined into a
single grid, test that the correct error is raised by the service.

DAS-1479

This can be tested locally by building the code from https://github.com/nasa/harmony-gdal-adapter/pull/16 and updating 

```
harmony_host_url = 'https://localhost:3000'
```
And using a local harmony client

```
collection_data = {
    'https://localhost:3000': {
        'env': Environment.UAT,
        'avnir_collection': Collection(id='C1244141281-EEDTEST'),
        'sentinel_collection': Collection(id='C1244141250-EEDTEST'),
        'uavsar_collection': Collection(id='C1244141264-EEDTEST'),
        'mur_collection': Collection(id='C1238621141-POCLOUD'),
    } 
}

environment_information = collection_data.get(harmony_host_url)

if environment_information is not None:
    harmony_client = Client(env=Environment.LOCAL)
```