### PR TITLE
Update regression tests to catch new raised exception.

### DIFF
--- a/test/hga/HGA_Regression.ipynb
+++ b/test/hga/HGA_Regression.ipynb
@@ -1481,7 +1481,7 @@
     "    try: \n",
     "        harmony_client.wait_for_processing(sentinel_job_id_thirteen, show_progress=True)\n",
     "    except Exception as exception:\n",
-    "        assert \"Request cannot be completed: datasets are incompatible and cannot be combined.\" in str(exception), 'Exception not raised correctly'\n",
+    "        assert \"Could not convert NetCDF-4 to GeoTIFF\" in str(exception), 'Exception not raised correctly'\n",
     "    print_success('Test raised expected Exception')\n",
     "else:\n",
     "    print('Skipping test: HGA regression tests not configured for this environment.')\n"


### PR DESCRIPTION
Before adding this we were not raising an exception when the netcdf4 file could
not be converted to GeoTIFF, and when we added that, we need to catch that in the old tests place..

DAS-1479