### PR TITLE
Harmony:1202- Fix regression test failure in UAT

### DIFF
--- a/test/harmony-regression/HarmonyRegression.ipynb
+++ b/test/harmony-regression/HarmonyRegression.ipynb
@@ -218,59 +218,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Shapefile Subsetting\n",
-    "\n",
-    "Only available in UAT. Remove UAT or SIT if statements and test/modify requests when available in PROD."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### PO.DAAC's Shapefile Subsetter "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "if is_not_prod:\n",
-    "    show_shape('zip://./notebook_helpers/test_in-polygon.shp.zip')\n",
-    "    show(get('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/shapefile_example/shapefile_r_001_249_20090109T000000.shp.zip'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "if is_not_prod:\n",
-    "    response = post(\n",
-    "        coverages_root.format(\n",
-    "            root=harmony_host_url,\n",
-    "            collection=shapefile_collection, \n",
-    "            variable='all'), \n",
-    "        data={ 'subset': 'time(\"2009-01-09T00:00:00Z\":\"2009-01-09T01:00:00Z\")' },\n",
-    "        files={ 'shapefile': ('test_in-polygon.shp.zip', open('./notebook_helpers/test_in-polygon.shp.zip', 'rb'), 'application/shapefile+zip') }\n",
-    "    )\n",
-    "\n",
-    "    try:\n",
-    "        show(response)\n",
-    "    except:\n",
-    "        print(response.text)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Zarr Reformatter"
    ]
   },


### PR DESCRIPTION
The required shapefile no longer exist so this check is eliminated completely as PODAAC has no services to support shapefile 