### PR TITLE
DAS-1495 - Make conda commands less verbose.

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,17 +8,16 @@ ENV env_notebook=$notebook
 WORKDIR /root
 
 RUN conda config --add channels conda-forge
-RUN pip install conda-lock
-RUN conda install conda-lock
+RUN conda install conda-lock -q -y
 
 COPY .netrc .netrc
 RUN mkdir ./${sub_dir}
 COPY ${sub_dir}/conda-linux-64.lock ./${sub_dir}
 
-RUN conda create --name papermill --file ./${sub_dir}/conda-linux-64.lock
+RUN conda create --name papermill --file ./${sub_dir}/conda-linux-64.lock -q -y
 
 # Install harmony-py within the conda environment
 # (harmony-py is available from PyPI, not conda)
-RUN conda install --name papermill -y pip; conda run --name papermill pip install harmony-py
+RUN conda install --name papermill -y -q pip; conda run --name papermill pip install -q harmony-py
 
 ENTRYPOINT export PATH=/opt/conda/envs/papermill/bin:$PATH; mkdir /root/output/${env_sub_dir}; papermill --cwd ${env_sub_dir} ${env_sub_dir}/${env_notebook} /root/output/${env_sub_dir}/Results.ipynb -p harmony_host_url $harmony_host_url


### PR DESCRIPTION
## Description

This PR arose from trawling through logs in Bamboo following test failures. This is an attempt to reduce the output from conda, so that the actual test results are easier to determine from the logs. As I bonus, I've also removed the Pip installation of `conda-lock` because this package was being installed via _both_ Pip and conda, and only needed to be installed by one of the two.

## Jira Issue ID

DAS-1495 - I've borrowed the ticket reference for the epic relating to SDS regression test changes for this PR.

## Local Test Steps

* Pull the new branch to your local environment.
* Build one of the Docker images (e.g., `make sds-image`).
* Use `run_notebooks.sh` to run the updated Docker image and ensure it installs everything correctly and the tests run.
