### PR TITLE
DAS-1590 - Update HOSS temporal regression test variable path.

### DIFF
--- a/test/sds/SDS_Regression.ipynb
+++ b/test/sds/SDS_Regression.ipynb
@@ -925,7 +925,7 @@
     "    hoss_temporal_file_name = 'hoss_temporal.nc4'\n",
     "    hoss_temporal_request = Request(collection=hoss_info['temporal_collection'],\n",
     "                                    granule_id=hoss_info['temporal_granule_id'],\n",
-    "                                    variables=['H1000'],\n",
+    "                                    variables=['/H1000'],\n",
     "                                    temporal={'start': datetime(2021, 6, 9, 12, 0, 0),\n",
     "                                              'stop': datetime(2021, 6, 9, 16, 0, 0)})\n",
     "\n",
@@ -1124,7 +1124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64f96581-a7bb-4221-ab8c-b4a81aa15a71",
+   "id": "9ab5efed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1701,7 +1701,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.13"
   },
   "name": "SDS_Regression.ipynb"
  },


### PR DESCRIPTION
## Description

This PR fixes an issue I discovered when running the HOSS regression tests. The temporal test no longer considers the `H1000` variable a valid path without a preceding `/`. This PR adds that slash.

## Jira Issue ID

DAS-1590 (discovered while testing)

## Local Test Steps

* Pull this branch locally.
* Start a Jupyter notebook server.
* Run all the cells prior to the Swath Projector tests.
* Run the first cell listed under "Harmony OPeNDAP SubSetter (HOSS)" (it sets up things including `hoss_info`.
* Run the "HOSS temporal subset request" test. It should run and pass.

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~
