### PR TITLE
DAS-1590 - Ensure all tests are wrapped in logic to only run for expected environments.

### DIFF
--- a/test/sds/SDS_Regression.ipynb
+++ b/test/sds/SDS_Regression.ipynb
@@ -1112,26 +1112,14 @@
     "                                     temporal=hoss_projected_info['temporal_range'])\n",
     "    submit_and_download(harmony_client, hoss_projected_request, hoss_projected_filename)\n",
     "    assert exists(hoss_projected_filename), 'Unsuccessful HOSS spatial subset request.'\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7565c0a9-67fe-42fd-a4fd-075020cb4f49",
-   "metadata": {},
-   "source": [
-    "### Load results and reference data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9ab5efed",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reference_data =  xr.open_dataset(hoss_projected_reference_filename)\n",
-    "output_data = xr.open_dataset(hoss_projected_filename) "
+    "    \n",
+    "    # Load data and make comparison:\n",
+    "    reference_data =  xr.open_dataset(hoss_projected_reference_filename)\n",
+    "    output_data = xr.open_dataset(hoss_projected_filename)\n",
+    "    assert output_data.equals(reference_data), 'reference and output datasets did not match'\n",
+    "    print_success('Subsetting projected grid with bounding box.')\n",
+    "else:\n",
+    "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
   },
   {
@@ -1149,17 +1137,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import cartopy.crs as ccrs\n",
-    "import cartopy.feature as cfeature\n",
+    "if hoss_projected_info is not None:\n",
+    "    import cartopy.crs as ccrs\n",
+    "    import cartopy.feature as cfeature\n",
     "\n",
-    "land = cfeature.NaturalEarthFeature(category='physical', name='land', scale='50m',\n",
-    "                                    facecolor=cfeature.COLORS['land'])\n",
-    "ocean = cfeature.NaturalEarthFeature(category='physical', name='ocean', scale='50m',\n",
-    "                                     facecolor=cfeature.COLORS['water'])\n",
+    "    land = cfeature.NaturalEarthFeature(category='physical', name='land', scale='50m',\n",
+    "                                        facecolor=cfeature.COLORS['land'])\n",
+    "    ocean = cfeature.NaturalEarthFeature(category='physical', name='ocean', scale='50m',\n",
+    "                                         facecolor=cfeature.COLORS['water'])\n",
     "\n",
-    "albers_projection = ccrs.AlbersEqualArea(central_longitude=-96.0, central_latitude=40.0,\n",
-    "                                         false_easting=0.0, false_northing=0.0,\n",
-    "                                         standard_parallels=(50.0, 70.0), globe=None)"
+    "    albers_projection = ccrs.AlbersEqualArea(central_longitude=-96.0, central_latitude=40.0,\n",
+    "                                             false_easting=0.0, false_northing=0.0,\n",
+    "                                             standard_parallels=(50.0, 70.0), globe=None)"
    ]
   },
   {
@@ -1169,27 +1158,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(16, 16))\n",
+    "if hoss_projected_info is not None:\n",
+    "    plt.figure(figsize=(16, 16))\n",
     "\n",
-    "ax = plt.subplot(1, 2, 1, projection=albers_projection)\n",
-    "ax.add_feature(ocean)\n",
-    "ax.add_feature(land)\n",
-    "ax.gridlines(color='gray', linestyle='dashed', draw_labels=True)\n",
-    "ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
-    "output_data.lon.plot.pcolormesh(ax=ax, transform=albers_projection,\n",
-    "                                x='x', y='y', cmap=plt.cm.turbo,\n",
-    "                                add_colorbar=False, zorder=2)\n",
-    "plt.title('Longitude (degrees east)')\n",
+    "    ax = plt.subplot(1, 2, 1, projection=albers_projection)\n",
+    "    ax.add_feature(ocean)\n",
+    "    ax.add_feature(land)\n",
+    "    ax.gridlines(color='gray', linestyle='dashed', draw_labels=True)\n",
+    "    ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
+    "    output_data.lon.plot.pcolormesh(ax=ax, transform=albers_projection,\n",
+    "                                    x='x', y='y', cmap=plt.cm.turbo,\n",
+    "                                    add_colorbar=False, zorder=2)\n",
+    "    plt.title('Longitude (degrees east)')\n",
     "\n",
-    "ax = plt.subplot(1, 2, 2, projection=albers_projection)\n",
-    "ax.add_feature(ocean)\n",
-    "ax.add_feature(land)\n",
-    "ax.gridlines(color='grey', linestyle='dashed', draw_labels=True)\n",
-    "ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
-    "output_data.lat.plot.pcolormesh(ax=ax, transform=albers_projection,\n",
-    "                                x='x', y='y', cmap=plt.cm.turbo,\n",
-    "                                add_colorbar=False, zorder=2)\n",
-    "plt.title('Latitude (degrees north)')"
+    "    ax = plt.subplot(1, 2, 2, projection=albers_projection)\n",
+    "    ax.add_feature(ocean)\n",
+    "    ax.add_feature(land)\n",
+    "    ax.gridlines(color='grey', linestyle='dashed', draw_labels=True)\n",
+    "    ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
+    "    output_data.lat.plot.pcolormesh(ax=ax, transform=albers_projection,\n",
+    "                                    x='x', y='y', cmap=plt.cm.turbo,\n",
+    "                                    add_colorbar=False, zorder=2)\n",
+    "    plt.title('Latitude (degrees north)')"
    ]
   },
   {
@@ -1199,18 +1189,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(18, 10))\n",
+    "if hoss_projected_info is not None:\n",
+    "    plt.figure(figsize=(18, 10))\n",
     "\n",
-    "ax = plt.axes(projection=albers_projection)\n",
-    "ax.add_feature(ocean)\n",
-    "ax.add_feature(land)\n",
-    "ax.gridlines(color='grey', linestyle='dashed')\n",
-    "ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
-    "output_data.NEE[0].plot.pcolormesh(ax=ax, transform=albers_projection,\n",
-    "                                   x='x', y='y', cmap=plt.cm.turbo, zorder=2)\n",
-    "plt.title('Output data for ABoVE TVPRM simulated Net Ecosystem Exchange\\n'\n",
-    "          '2008-01-01T00:30:00Z')\n",
-    "plt.show()"
+    "    ax = plt.axes(projection=albers_projection)\n",
+    "    ax.add_feature(ocean)\n",
+    "    ax.add_feature(land)\n",
+    "    ax.gridlines(color='grey', linestyle='dashed')\n",
+    "    ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
+    "    output_data.NEE[0].plot.pcolormesh(ax=ax, transform=albers_projection,\n",
+    "                                       x='x', y='y', cmap=plt.cm.turbo, zorder=2)\n",
+    "    plt.title('Output data for ABoVE TVPRM simulated Net Ecosystem Exchange\\n'\n",
+    "              '2008-01-01T00:30:00Z')\n",
+    "    plt.show()"
    ]
   },
   {
@@ -1218,7 +1209,9 @@
    "id": "f23c5fa2-88db-4b93-afb6-b9a0161a11c2",
    "metadata": {},
    "source": [
-    "### Compare output data with reference data"
+    "### Clean up `xarray` objects:\n",
+    "\n",
+    "Using a context manager for `xarray.Dataset` does not remove the variable assignment as part of the `.__exit__` method."
    ]
   },
   {
@@ -1228,10 +1221,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert output_data.equals(reference_data), 'reference and output datasets did not match'\n",
-    "print_success('Subsetting projected grid with bounding box.')\n",
-    "del reference_data\n",
-    "del output_data"
+    "if hoss_projected_info is not None:\n",
+    "    del reference_data\n",
+    "    del output_data"
    ]
   },
   {
@@ -1265,26 +1257,14 @@
     "                                     temporal=hoss_projected_info['temporal_range'])\n",
     "    submit_and_download(harmony_client, hoss_projected_request, hoss_projected_shape_filename)\n",
     "    assert exists(hoss_projected_shape_filename), 'Unsuccessful HOSS shapefile spatial subset request.'\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7d224396-4d8e-44f9-bd87-635c54eafbe5",
-   "metadata": {},
-   "source": [
-    "### Load reference and output data. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c0e45903-aa1d-4bde-947f-d4b6b8759050",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reference_data =  xr.open_dataset(hoss_projected_reference_filename)\n",
-    "output_data = xr.open_dataset(hoss_projected_shape_filename)"
+    "\n",
+    "    # Load output data and compare to a reference image:\n",
+    "    reference_data =  xr.open_dataset(hoss_projected_reference_filename)\n",
+    "    output_data = xr.open_dataset(hoss_projected_shape_filename)\n",
+    "    assert output_data.equals(reference_data), 'reference and output datasets did not match'\n",
+    "    print_success('Subsetting projected grid with shapefile.')\n",
+    "else:\n",
+    "    print(f'HOSS is not configured for environment: \"{harmony_environment}\" - skipping test.')"
    ]
   },
   {
@@ -1302,27 +1282,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(16, 16))\n",
+    "if hoss_projected_info is not None:\n",
+    "    plt.figure(figsize=(16, 16))\n",
     "\n",
-    "ax = plt.subplot(1, 2, 1, projection=albers_projection)\n",
-    "ax.add_feature(ocean)\n",
-    "ax.add_feature(land)\n",
-    "ax.gridlines(color='gray', linestyle='dashed', draw_labels=True)\n",
-    "ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
-    "output_data.lon.plot.pcolormesh(ax=ax, transform=albers_projection,\n",
-    "                                x='x', y='y', cmap=plt.cm.turbo,\n",
-    "                                add_colorbar=False, zorder=2)\n",
-    "plt.title('Longitude (degrees east)')\n",
+    "    ax = plt.subplot(1, 2, 1, projection=albers_projection)\n",
+    "    ax.add_feature(ocean)\n",
+    "    ax.add_feature(land)\n",
+    "    ax.gridlines(color='gray', linestyle='dashed', draw_labels=True)\n",
+    "    ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
+    "    output_data.lon.plot.pcolormesh(ax=ax, transform=albers_projection,\n",
+    "                                    x='x', y='y', cmap=plt.cm.turbo,\n",
+    "                                    add_colorbar=False, zorder=2)\n",
+    "    plt.title('Longitude (degrees east)')\n",
     "\n",
-    "ax = plt.subplot(1, 2, 2, projection=albers_projection)\n",
-    "ax.add_feature(ocean)\n",
-    "ax.add_feature(land)\n",
-    "ax.gridlines(color='grey', linestyle='dashed', draw_labels=True)\n",
-    "ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
-    "output_data.lat.plot.pcolormesh(ax=ax, transform=albers_projection,\n",
-    "                                x='x', y='y', cmap=plt.cm.turbo,\n",
-    "                                add_colorbar=False, zorder=2)\n",
-    "plt.title('Latitude (degrees north)')"
+    "    ax = plt.subplot(1, 2, 2, projection=albers_projection)\n",
+    "    ax.add_feature(ocean)\n",
+    "    ax.add_feature(land)\n",
+    "    ax.gridlines(color='grey', linestyle='dashed', draw_labels=True)\n",
+    "    ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
+    "    output_data.lat.plot.pcolormesh(ax=ax, transform=albers_projection,\n",
+    "                                    x='x', y='y', cmap=plt.cm.turbo,\n",
+    "                                    add_colorbar=False, zorder=2)\n",
+    "    plt.title('Latitude (degrees north)')"
    ]
   },
   {
@@ -1332,18 +1313,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(18, 10))\n",
+    "if hoss_projected_info is not None:\n",
+    "    plt.figure(figsize=(18, 10))\n",
     "\n",
-    "ax = plt.axes(projection=albers_projection)\n",
-    "ax.add_feature(ocean)\n",
-    "ax.add_feature(land)\n",
-    "ax.gridlines(color='grey', linestyle='dashed')\n",
-    "ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
-    "output_data.NEE[0].plot.pcolormesh(ax=ax, transform=albers_projection,\n",
-    "                                   x='x', y='y', cmap=plt.cm.turbo, zorder=2)\n",
-    "plt.title('Output data for ABoVE TVPRM simulated Net Ecosystem Exchange\\n'\n",
-    "          '2008-01-01T00:30:00Z')\n",
-    "plt.show()"
+    "    ax = plt.axes(projection=albers_projection)\n",
+    "    ax.add_feature(ocean)\n",
+    "    ax.add_feature(land)\n",
+    "    ax.gridlines(color='grey', linestyle='dashed')\n",
+    "    ax.set_extent([-2330000, -1800000, 3900000, 4500000], albers_projection)\n",
+    "    output_data.NEE[0].plot.pcolormesh(ax=ax, transform=albers_projection,\n",
+    "                                       x='x', y='y', cmap=plt.cm.turbo, zorder=2)\n",
+    "    plt.title('Output data for ABoVE TVPRM simulated Net Ecosystem Exchange\\n'\n",
+    "              '2008-01-01T00:30:00Z')\n",
+    "    plt.show()"
    ]
   },
   {
@@ -1351,7 +1333,7 @@
    "id": "bf78c79c-0fc0-4dea-885e-b0e862e74f94",
    "metadata": {},
    "source": [
-    "### Compare output data with reference data"
+    "### Clean up `xarray` objects:"
    ]
   },
   {
@@ -1361,10 +1343,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert output_data.equals(reference_data), 'reference and output datasets did not match'\n",
-    "print_success('Subsetting projected grid with shapefile.')\n",
-    "del reference_data\n",
-    "del output_data"
+    "if hoss_projected_info is not None:\n",
+    "    del reference_data\n",
+    "    del output_data"
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR fixes a bug introduced with the regression tests for using HOSS/MaskFill with a projection-gridded collection. While the cell that submits the Harmony request is wrapped in logic to only run the test for environments that are configured for testing, the plotting cells were not. When running the tests against the production environment, these latter cells were throwing errors, primarily because they refer to variables defined in code blocks that don't get run in that first cell.

This PR updates these tests to wrap all associated cells in conditional logic to only run the plotting functionality if the environment that the tests are run against has data configured to test with.

## Jira Issue ID

DAS-1590

## Local Test Steps

* Pull this branch of the repository.
* Run the notebook twice - first against UAT, then against Prod.
* The UAT tests should all run, including plotting the projection-gridded HOSS/MaskFill test results.
* The Production tests should essentially skip everything, but the notebook should not cause an error.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
