### PR TITLE
Add test-in-bamboo.sh option

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,15 +179,17 @@ documentation on setting parameters.
 New test suites must be added to the `Makefile`. A new `name-image` target (where name is the name of
 the test suite) should be added (see the `harmony-image` example), and the new image target
 should be added as a dependency of the `images` target. The docker image should have a name like
-`harmony/regression-tests-<base_name>`, where `base_name` is the name of the test suite.
+`ghcr.io/nasa/regression-tests-<base_name>`, where `base_name` is the name of the test suite.
+
 
 To build the test images on github, add a new matrix target that includes the
 image base name and notbook name to the list of targets in the
 `.github/workflows/build-all-images.yml` file.
 
-Finally, add the image base name to the `images` array on line 6 of the `run_notebooks.sh` file.
-For instance, if the image is named `harmony/regression-tests-foo`, then we would add `foo` to the
-array.
+Finally, add the image base name to the `images` array on line 6 of the
+`run_notebooks.sh` file and line 20 of scripts/test-in-bamboo.sh. For instance,
+if the image is named `ghcr.io/nasa/regression-tests-foo`, then we would add
+`foo` to the arrays.
 
 The `run_notebooks.sh` file can be used as described above to run the test suite. Notebooks are
 expected to exit with a non-zero exit code on failure when run from `papermill`.

--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ To build the test images on github, add a new matrix target that includes the
 image base name and notbook name to the list of targets in the
 `.github/workflows/build-all-images.yml` file.
 
-Finally, add the image base name to the `images` array on line 6 of the
-`run_notebooks.sh` file and line 20 of scripts/test-in-bamboo.sh. For instance,
-if the image is named `ghcr.io/nasa/regression-tests-foo`, then we would add
-`foo` to the arrays.
+Finally, add the image base name to the `all_images` array in the
+`run_notebooks.sh` file and the `all_tests` array in `scripts/test-in-bamboo.sh` script. For instance,
+if the new image is named `ghcr.io/nasa/regression-tests-foo`, then we would add
+`foo` to both arrays.
 
 The `run_notebooks.sh` file can be used as described above to run the test suite. Notebooks are
 expected to exit with a non-zero exit code on failure when run from `papermill`.

--- a/script/clean-up-docker-images.sh
+++ b/script/clean-up-docker-images.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# removes any images downloaded by the test-in-bamboo.sh script.
+# test-in-bamboo.sh writes to pulled-images.txt
+
+while read -r line
+do
+    echo "removing $line"
+    docker rmi "$line"
+done < pulled-images.txt

--- a/script/clean-up-docker-images.sh
+++ b/script/clean-up-docker-images.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # removes any images downloaded by the test-in-bamboo.sh script.
-# test-in-bamboo.sh writes to pulled-images.txt
+# test-in-bamboo.sh writes to a pulled-images.txt, and we read that file here.
 
 while read -r line
 do

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -5,6 +5,16 @@
 
 set -ex
 
+## Returns the correct image name to pull from docker.  If the test name's
+## environmental variable exists, return that, otherwise return the default
+## value for the image.
+function image_name () {
+    base="regression-tests-$1"
+    env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    default_image="ghcr.io/nasa/${base}:latest"
+    echo "${!env_image_name:-${default_image}}"
+}
+
 if [[ -z "${HARMONY_ENVIRONMENT}" ]]; then
   echo "HARMONY_ENVIRONMENT must be set to run this script"
   exit 1
@@ -37,14 +47,9 @@ echo "harmony host url: ${harmony_host_url}"
 ## e.g. if REGRESSION_TESTS_N2Z_IMAGE environment was set, the value would be used instead of the default.
 
 image_names=()
-container_repository="ghcr.io/nasa/"
 all_tests=(harmony harmony-regression hoss hga n2z swath-projector trajectory-subsetter variable-subsetter regridder)
-
 for image in "${all_tests[@]}"; do
-    base="regression-tests-${image}"
-    env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-    default_image="${container_repository}${base}:latest"
-    image_names+=("${!env_image_name:-${default_image}}")
+    image_names+=($(image_name "$image"))
 done
 
 # download all of the images and output their names

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+## Script to download regression images and run the regression tests.
+
+set -e
+
+if [[ -z "${HARMONY_ENVIRONMENT}" ]]; then
+  echo "HARMONY_ENVIRONMENT must be set to run this script"
+  exit 1
+fi
+
+case $HARMONY_ENVIRONMENT in
+uat)
+  harmony_host_url="https://harmony.uat.earthdata.nasa.gov"
+  ;;
+prod)
+  harmony_host_url="https://harmony.earthdata.nasa.gov"
+  ;;
+sit)
+  harmony_host_url="https://harmony.sit.earthdata.nasa.gov"
+  ;;
+*)
+  echo "Valid environments are sit, uat, and prod."
+  exit 1
+  ;;
+esac
+
+echo "harmony host url: ${harmony_host_url}"
+
+
+## download test versions of the regression images from GitHub container registry.
+## default images are pulled for each image in the all_images array
+## deault images are : "ghrc.io/nasa/regression-tests-<image>:latest"
+## Any bamboo variables named "REGRESSION_TESTS_<IMAGE>_VERSION" will override the default value.
+image_names=()
+container_repository="ghcr.io/nasa/"
+all_images=(harmony harmony-regression hoss hga n2z swath-projector trajectory-subsetter variable-subsetter regridder)
+
+for image in "${all_images[@]}"; do
+    base="regression-tests-${image}"
+    ENV_NAME=$(echo ${base}-version | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    default="${container_repository}${base}:latest"
+    image_names+=("${!ENV_NAME:-${default}}")
+done
+
+
+for image in "${image_names[@]}"; do
+    echo "Pulling image: ${image}"
+    docker pull ${image}
+done
+
+
+cd test \
+    && export HARMONY_HOST_URL="${HARMONY_HOST_URL}" \
+	      AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+	      AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+	      EDL_USER="${EDL_USER}" \
+	      EDL_PASSWORD="${EDL_PASSWORD}" \
+    && ./run_notebooks.sh

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -38,15 +38,17 @@ all_images=(harmony harmony-regression hoss hga n2z swath-projector trajectory-s
 
 for image in "${all_images[@]}"; do
     base="regression-tests-${image}"
-    ENV_NAME=$(echo ${base}-version | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    ENV_NAME=$(echo "${base}-version" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
     default="${container_repository}${base}:latest"
     image_names+=("${!ENV_NAME:-${default}}")
 done
 
 
+/bin/rm -f pulled-docker-images.txt
 for image in "${image_names[@]}"; do
     echo "Pulling image: ${image}"
-    docker pull ${image}
+    echo "${image}" >> pulled-images.txt
+    docker pull "${image}"
 done
 
 

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -29,16 +29,16 @@ echo "harmony host url: ${harmony_host_url}"
 
 
 ## download test versions of the regression images from GitHub container registry.
-## default images are pulled for each image in the all_images array
-## deault images are : "ghrc.io/nasa/regression-tests-<image>:latest"
-## Any bamboo variables named "REGRESSION_TESTS_<IMAGE>_VERSION" will override the default value.
+## default images are pulled for each test in the all_tests array
+## deault images are : "ghrc.io/nasa/regression-tests-<test>:latest"
+## Any bamboo variables named "REGRESSION_TESTS_<test>_IMAGE" will override the default value.
 image_names=()
 container_repository="ghcr.io/nasa/"
-all_images=(harmony harmony-regression hoss hga n2z swath-projector trajectory-subsetter variable-subsetter regridder)
+all_tests=(harmony harmony-regression hoss hga n2z swath-projector trajectory-subsetter variable-subsetter regridder)
 
-for image in "${all_images[@]}"; do
+for image in "${all_tests[@]}"; do
     base="regression-tests-${image}"
-    ENV_NAME=$(echo "${base}-version" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    ENV_NAME=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
     default="${container_repository}${base}:latest"
     image_names+=("${!ENV_NAME:-${default}}")
 done

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
 ## Script to download regression images and run the regression tests.
+## Intended to be run as part of Continuous Integration in Bamboo.
 
-set -e
+set -ex
 
 if [[ -z "${HARMONY_ENVIRONMENT}" ]]; then
   echo "HARMONY_ENVIRONMENT must be set to run this script"
   exit 1
 fi
 
+# choose the correct harmony host.
 case $HARMONY_ENVIRONMENT in
 uat)
   harmony_host_url="https://harmony.uat.earthdata.nasa.gov"
@@ -28,22 +30,24 @@ esac
 echo "harmony host url: ${harmony_host_url}"
 
 
-## download test versions of the regression images from GitHub container registry.
-## default images are pulled for each test in the all_tests array
-## deault images are : "ghrc.io/nasa/regression-tests-<test>:latest"
+## Download test versions of the regression images from GitHub container registry.
+## Images are pulled for each test in the all_tests array
+## default images have a pattern: "ghrc.io/nasa/regression-tests-<test>:latest"
 ## Any bamboo variables named "REGRESSION_TESTS_<test>_IMAGE" will override the default value.
+## e.g. any REGRESSION_TESTS_N2Z_IMAGE environemnt set would be used instead of the default.
+
 image_names=()
 container_repository="ghcr.io/nasa/"
 all_tests=(harmony harmony-regression hoss hga n2z swath-projector trajectory-subsetter variable-subsetter regridder)
 
 for image in "${all_tests[@]}"; do
     base="regression-tests-${image}"
-    ENV_NAME=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-    default="${container_repository}${base}:latest"
-    image_names+=("${!ENV_NAME:-${default}}")
+    env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    default_image="${container_repository}${base}:latest"
+    image_names+=("${!env_image_name:-${default_image}}")
 done
 
-
+# download all of the images and output their names
 /bin/rm -f pulled-docker-images.txt
 for image in "${image_names[@]}"; do
     echo "Pulling image: ${image}"
@@ -51,7 +55,7 @@ for image in "${image_names[@]}"; do
     docker pull "${image}"
 done
 
-
+## run the tests
 cd test \
     && export HARMONY_HOST_URL="${HARMONY_HOST_URL}" \
 	      AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -34,7 +34,7 @@ echo "harmony host url: ${harmony_host_url}"
 ## Images are pulled for each test in the all_tests array
 ## default images have a pattern: "ghrc.io/nasa/regression-tests-<test>:latest"
 ## Any bamboo variables named "REGRESSION_TESTS_<test>_IMAGE" will override the default value.
-## e.g. any REGRESSION_TESTS_N2Z_IMAGE environemnt set would be used instead of the default.
+## e.g. if REGRESSION_TESTS_N2Z_IMAGE environment was set, the value would be used instead of the default.
 
 image_names=()
 container_repository="ghcr.io/nasa/"

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -57,7 +57,7 @@ done
 
 ## run the tests
 cd test \
-    && export HARMONY_HOST_URL="${HARMONY_HOST_URL}" \
+    && export HARMONY_HOST_URL="${harmony_host_url}" \
 	      AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
 	      AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
 	      EDL_USER="${EDL_USER}" \

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,28 +1,28 @@
 harmony-image: Dockerfile harmony/environment.yaml
-	docker build -t harmony/regression-tests-harmony:latest -f ./Dockerfile --build-arg notebook=Harmony.ipynb --build-arg sub_dir=harmony .
+	docker build -t ghcr.io/nasa/regression-tests-harmony:latest -f ./Dockerfile --build-arg notebook=Harmony.ipynb --build-arg sub_dir=harmony .
 
 harmony-regression-image: Dockerfile harmony-regression/environment.yaml
-	docker build -t harmony/regression-tests-harmony-regression:latest -f ./Dockerfile --build-arg notebook=HarmonyRegression.ipynb --build-arg sub_dir=harmony-regression .
+	docker build -t ghcr.io/nasa/regression-tests-harmony-regression:latest -f ./Dockerfile --build-arg notebook=HarmonyRegression.ipynb --build-arg sub_dir=harmony-regression .
 
 hga-image: Dockerfile hga/environment.yaml
-	docker build -t harmony/regression-tests-hga:latest -f ./Dockerfile --build-arg notebook=HGA_Regression.ipynb --build-arg sub_dir=hga .
+	docker build -t ghcr.io/nasa/regression-tests-hga:latest -f ./Dockerfile --build-arg notebook=HGA_Regression.ipynb --build-arg sub_dir=hga .
 
 hoss-image: Dockerfile hoss/environment.yaml
-	docker build -t harmony/regression-tests-hoss:latest -f ./Dockerfile --build-arg notebook=HOSS_Regression.ipynb --build-arg sub_dir=hoss .
+	docker build -t ghcr.io/nasa/regression-tests-hoss:latest -f ./Dockerfile --build-arg notebook=HOSS_Regression.ipynb --build-arg sub_dir=hoss .
 
 n2z-image: Dockerfile n2z/environment.yaml
-	docker build -t harmony/regression-tests-n2z:latest -f ./Dockerfile --build-arg notebook=N2Z_Regression.ipynb --build-arg sub_dir=n2z .
+	docker build -t ghcr.io/nasa/regression-tests-n2z:latest -f ./Dockerfile --build-arg notebook=N2Z_Regression.ipynb --build-arg sub_dir=n2z .
 
 regridder-image: Dockerfile regridder/environment.yaml
-	docker build -t harmony/regression-tests-regridder:latest -f ./Dockerfile --build-arg notebook=Regridder_Regression.ipynb --build-arg sub_dir=regridder .
+	docker build -t ghcr.io/nasa/regression-tests-regridder:latest -f ./Dockerfile --build-arg notebook=Regridder_Regression.ipynb --build-arg sub_dir=regridder .
 
 swath-projector-image: Dockerfile swath-projector/environment.yaml
-	docker build -t harmony/regression-tests-swath-projector:latest -f ./Dockerfile --build-arg notebook=SwathProjector_Regression.ipynb --build-arg sub_dir=swath-projector .
+	docker build -t ghcr.io/nasa/regression-tests-swath-projector:latest -f ./Dockerfile --build-arg notebook=SwathProjector_Regression.ipynb --build-arg sub_dir=swath-projector .
 
 trajectory-subsetter-image: Dockerfile trajectory-subsetter/environment.yaml
-	docker build -t harmony/regression-tests-trajectory-subsetter:latest -f ./Dockerfile --build-arg notebook=TrajectorySubsetter_Regression.ipynb --build-arg sub_dir=trajectory-subsetter .
+	docker build -t ghcr.io/nasa/regression-tests-trajectory-subsetter:latest -f ./Dockerfile --build-arg notebook=TrajectorySubsetter_Regression.ipynb --build-arg sub_dir=trajectory-subsetter .
 
 variable-subsetter-image: Dockerfile variable-subsetter/environment.yaml
-	docker build -t harmony/regression-tests-variable-subsetter:latest -f ./Dockerfile --build-arg notebook=VariableSubsetter_Regression.ipynb --build-arg sub_dir=variable-subsetter .
+	docker build -t ghcr.io/nasa/regression-tests-variable-subsetter:latest -f ./Dockerfile --build-arg notebook=VariableSubsetter_Regression.ipynb --build-arg sub_dir=variable-subsetter .
 
-images: harmony-image harmony-regression-image hga-image hoss-image n2z-image swath-projector-image trajectory-subsetter-image variable-subsetter-image
+images: harmony-image harmony-regression-image hga-image hoss-image n2z-image regridder-image swath-projector-image trajectory-subsetter-image variable-subsetter-image

--- a/test/run_notebooks.sh
+++ b/test/run_notebooks.sh
@@ -26,7 +26,7 @@ for image in "${images[@]}"; do
 		     -v ${PWD}/${image}:/root/${image} \
 		      ${creds} \
 		      --env EDL_PASSWORD="${EDL_PASSWORD}" --env EDL_USER="${EDL_USER}" \
-		      --env harmony_host_url="${HARMONY_HOST_URL}" "harmony/regression-tests-${image}:latest"))
+		      --env harmony_host_url="${HARMONY_HOST_URL}" "ghcr.io/nasa/regression-tests-${image}:latest"))
 done
 
 trap ctrl_c SIGINT SIGTERM

--- a/test/run_notebooks.sh
+++ b/test/run_notebooks.sh
@@ -4,7 +4,19 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+## Returns the correct image name.  If the test name's
+## environmental variable exists, return that, otherwise return the default
+## value for the image.
+function image_name () {
+    base="regression-tests-$1"
+    env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    default_image="ghcr.io/nasa/${base}:latest"
+    echo "${!env_image_name:-${default_image}}"
+}
+
+
 echo "Running regression tests"
+
 
 # Specify the test images to run, by default all built by the Makefile. If
 # the script is invoked with a list of images, only run those.
@@ -22,11 +34,14 @@ for image in "${images[@]}"; do
     else
 	creds=""
     fi
+
+    full_image=$(image_name "$image")
+    echo "running test with $full_image"
     PIDS+=(${image},$(docker run -d -v ${PWD}/output:/root/output \
 		     -v ${PWD}/${image}:/root/${image} \
 		      ${creds} \
 		      --env EDL_PASSWORD="${EDL_PASSWORD}" --env EDL_USER="${EDL_USER}" \
-		      --env harmony_host_url="${HARMONY_HOST_URL}" "ghcr.io/nasa/regression-tests-${image}:latest"))
+		      --env harmony_host_url="${HARMONY_HOST_URL}" "${full_image}"))
 done
 
 trap ctrl_c SIGINT SIGTERM


### PR DESCRIPTION
## Description

Adds script/test-in-bamboo.sh in order to simplify regression testing.  This
script downloads the regression test images from github's container registry
and then runs the run_notebooks.sh testing script.

Additionally it renames the default images from `harmony/regression-test-<img>` to `ghrc.io/nasa/regression-test-<img>`

## Jira Issue ID

DAS-1761

## Local Test Steps

If you set these environmental variables:

``` text
HARMONY_ENVIRONMENT
HARMONY_HOST_URL
AWS_SECRET_ACCESS_KEY
AWS_ACCESS_KEY_ID
EDL_USER
EDL_PASSWORD
```

From your project root directory, you should be able to run:

``` bash
./scripts/test-in-bamboo.sh
```

And see it download the default images and run the regression tests.

After it finishes, you can run 

``` bash
./script/clean-up-docker-images.sh
```
And watch it clean up all of the pulled docker images from your machine.



## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)