### PR TITLE
DAS-1747 - Push notebook outputs to S3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ output/*
 .identity
 .netrc
 
+**pulled-images.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ output/*
 .identity
 .netrc
 
-**pulled-images.txt
+**/pulled-images.txt

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -70,4 +70,6 @@ cd test \
     && ./run_notebooks.sh
 
 # Copy the notebook artefacts up to S3:
-aws s3 cp output "s3://${REGRESSION_TEST_OUTPUT_BUCKET}" --recursive
+if [[ -z "${REGRESSION_TEST_OUTPUT_BUCKET}" ]]; then
+  aws s3 cp output "s3://${REGRESSION_TEST_OUTPUT_BUCKET}" --recursive
+fi

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -68,3 +68,6 @@ cd test \
 	      EDL_USER="${EDL_USER}" \
 	      EDL_PASSWORD="${EDL_PASSWORD}" \
     && ./run_notebooks.sh
+
+# Copy the notebook artefacts up to S3:
+aws s3 cp output "s3://${REGRESSION_TEST_OUTPUT_BUCKET}" --recursive


### PR DESCRIPTION
## Description

This PR ensures that the current Bamboo behaviour of pushing output notebooks to a bucket in the relevant Harmony S3 bucket is maintained.

## Jira Issue ID

DAS-1747.

## Local Test Steps

* Run this script with appropriate environment variables set for authentication against the correct Harmony environment. Upon completion the output notebooks should be correctly pushed to S3.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~