### PR TITLE
DAS-1747 - Ensure aws s3 cp called when REGRESSION_TEST_OUTPUT_BUCKET is set.

### DIFF
--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -71,5 +71,7 @@ cd test \
 
 # Copy the notebook artefacts up to S3:
 if [[ -z "${REGRESSION_TEST_OUTPUT_BUCKET}" ]]; then
+  echo "REGRESSION_TEST_OUTPUT_BUCKET environment variable not set."
+else
   aws s3 cp output "s3://${REGRESSION_TEST_OUTPUT_BUCKET}" --recursive
 fi


### PR DESCRIPTION
## Description

The previous PR I made did exactly the opposite of what it should... it the test-in-bamboo.sh script will currently only try to push to S3 when `REGRESSION_TEST_OUTPUT_BUCKET` has zero length. This PR fixes that.

Otherwise, things are behaving as expected in Bamboo. :tada:
## Jira Issue ID

DAS-1747

## Local Test Steps

Use the if-else logic from the bottom of the script to check it behave as expected when the environment variable for the S3 bucket is, or is not set.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~
