### PR TITLE
DAS-1970: Switches image tag to be read from version.txt

### DIFF
--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -5,13 +5,15 @@
 
 set -ex
 
-## Returns the correct image name to pull from docker.  If the test name's
+
+## Returns the image name to pull from docker.  If the test name's
 ## environmental variable exists, return that, otherwise return the default
-## value for the image.
+## value for the image read from the version.txt file.
 function image_name () {
     base="regression-tests-$1"
+    recent_tag=$(<"./test/$1/version.txt")
     env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-    default_image="ghcr.io/nasa/${base}:latest"
+    default_image="ghcr.io/nasa/${base}:${recent_tag}"
     echo "${!env_image_name:-${default_image}}"
 }
 


### PR DESCRIPTION
## Description

What the title says:

Before,  'latest' was the the default tag/value for an image that did not have corresponding bamboo environment variable.
Now, it reads the tag from the `version.txt` associated with the image.

## Jira Issue ID

[DAS-1970](https://bugs.earthdata.nasa.gov/browse/DAS-1970)

## Local Test Steps

I don't think this can be tested locally.  But if you checkout this branch and run the changed script from the root directory.

``` sh
HARMONY_ENV=sit ./script-test-in-bamboo.sh
```

You should see the file pull all regression images with their respective tags:

Pulling image: ghcr.io/nasa/regression-tests-harmony:0.1.3


~Additionally, when this is merged, all of the image values in SIT Bamboo should be deleted. The image names, can remain, but their values should be empty. This should let the actual image tag show up in the regression test logs.~



## PR Acceptance Checklist
* [ X ] Acceptance criteria met
* [ n/a ] Tests added/updated (if needed) and passing
* [ n/a ] Documentation updated (if needed)