### PR TITLE
DAS-1970: bugfix

### DIFF
--- a/script/image_name.sh
+++ b/script/image_name.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+## Returns the correct image name to run a notebook.
+## If the test name's environmental variable exists, return that.
+## otherwise:
+##   if the second argument passed is 'true' return the tag value for the image read from the version.txt file.
+##   else returns 'latest'
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+function image_name () {
+    base="regression-tests-$1"
+    if [ "$2" = true ]; then
+	recent_tag=$(<"$SCRIPT_DIR/../test/$1/version.txt")
+    else
+	recent_tag="latest"
+    fi
+    env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+    default_image="ghcr.io/nasa/${base}:${recent_tag}"
+    echo "${!env_image_name:-${default_image}}"
+}

--- a/script/image_name.sh
+++ b/script/image_name.sh
@@ -10,9 +10,9 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 function image_name () {
     base="regression-tests-$1"
     if [ "$2" = true ]; then
-	recent_tag=$(<"$SCRIPT_DIR/../test/$1/version.txt")
+        recent_tag=$(<"$SCRIPT_DIR/../test/$1/version.txt")
     else
-	recent_tag="latest"
+        recent_tag="latest"
     fi
     env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
     default_image="ghcr.io/nasa/${base}:${recent_tag}"

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -58,10 +58,10 @@ done
 ## run the tests
 cd test \
     && export HARMONY_HOST_URL="${harmony_host_url}" \
-	      AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
-	      AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
-	      EDL_USER="${EDL_USER}" \
-	      EDL_PASSWORD="${EDL_PASSWORD}" \
+              AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
+              AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
+              EDL_USER="${EDL_USER}" \
+              EDL_PASSWORD="${EDL_PASSWORD}" \
     && ./run_notebooks.sh --use-versions
 
 # Copy the notebook artefacts up to S3:

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -5,19 +5,10 @@
 
 set -ex
 
+
+## Import function image_name that determines the images to pull from docker.
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-
-## Returns the image name to pull from docker.  If the test name's
-## environmental variable exists, return that, otherwise return the default
-## value for the image read from the version.txt file.
-function image_name () {
-    base="regression-tests-$1"
-    recent_tag=$(<"$SCRIPT_DIR/../test/$1/version.txt")
-    env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-    default_image="ghcr.io/nasa/${base}:${recent_tag}"
-    echo "${!env_image_name:-${default_image}}"
-}
+source "${SCRIPT_DIR}/image_name.sh"
 
 if [[ -z "${HARMONY_ENVIRONMENT}" ]]; then
   echo "HARMONY_ENVIRONMENT must be set to run this script"
@@ -53,7 +44,7 @@ echo "harmony host url: ${harmony_host_url}"
 image_names=()
 all_tests=(harmony harmony-regression hoss hga n2z swath-projector trajectory-subsetter variable-subsetter regridder hybig)
 for image in "${all_tests[@]}"; do
-    image_names+=($(image_name "$image"))
+    image_names+=($(image_name "$image" true))
 done
 
 # download all of the images and output their names

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -71,7 +71,7 @@ cd test \
 	      AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
 	      EDL_USER="${EDL_USER}" \
 	      EDL_PASSWORD="${EDL_PASSWORD}" \
-    && ./run_notebooks.sh
+    && ./run_notebooks.sh --use-versions
 
 # Copy the notebook artefacts up to S3:
 if [[ -z "${REGRESSION_TEST_OUTPUT_BUCKET}" ]]; then

--- a/script/test-in-bamboo.sh
+++ b/script/test-in-bamboo.sh
@@ -5,13 +5,15 @@
 
 set -ex
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 
 ## Returns the image name to pull from docker.  If the test name's
 ## environmental variable exists, return that, otherwise return the default
 ## value for the image read from the version.txt file.
 function image_name () {
     base="regression-tests-$1"
-    recent_tag=$(<"./test/$1/version.txt")
+    recent_tag=$(<"$SCRIPT_DIR/../test/$1/version.txt")
     env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
     default_image="ghcr.io/nasa/${base}:${recent_tag}"
     echo "${!env_image_name:-${default_image}}"

--- a/test/run_notebooks.sh
+++ b/test/run_notebooks.sh
@@ -4,26 +4,11 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
+## Import function that returns correct image names.  if flag --use-versions is
+## set when this script is called, it will use names form versions.txt
+## otherwise it will default to "latest"
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-
-
-## Returns the correct image name to run a notebook.
-## If the test name's environmental variable exists, return that.
-## otherwise:
-##   if the second argument passed is 'true' return the tag value for the image read from the version.txt file.
-##   else returns 'latest'
-function image_name () {
-    base="regression-tests-$1"
-    if [ "$2" = true ]; then
-	recent_tag=$(<"$SCRIPT_DIR/$1/version.txt")
-    else
-	recent_tag="latest"
-    fi
-    env_image_name=$(echo "${base}_IMAGE" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-    default_image="ghcr.io/nasa/${base}:${recent_tag}"
-    echo "${!env_image_name:-${default_image}}"
-}
-
+source "${SCRIPT_DIR}/../script/image_name.sh"
 
 echo "Running regression tests"
 


### PR DESCRIPTION
## Description

Read from version.txt in both run_notebooks.sh and test-in-bamboo.sh

Uses SCRIPT_DIR to correctly locate version.txt
Parses the bash input parameters for `run_notebooks.sh`

When `run_notebooks.sh` is run with no params or with a list of tests to
run. e.g. `hga n2z` it will run with the latest image that must be built
locally (no change from how this worked before).  The change is that
`run_notebooks.sh` now takes a flag `--use-versions` which will control whether
`latest` or the value from `version.txt` is used as the docker image tag.

This flag is set in the `test-in-bamboo.sh` file so that CI will always run with the tagged version from version.txt (if it's not overridden by bamboo environment variables.)


## Jira Issue ID

[DAS-1970](https://bugs.earthdata.nasa.gov/browse/DAS-1970)


## Local Test Steps

You can checkout this branch and run the changed script from the root directory (or any directory).

HARMONY_ENV=sit ./scripts/test-in-bamboo.sh

You should see the file pull all regression images with their respective tags:

Pulling image: ghcr.io/nasa/regression-tests-harmony:0.1.3

If you set your SIT environment variables

``` shell
export AWS_ACCESS_KEY_ID=
export AWS_SECRET_ACCESS_KEY=
export EDL_USER=
export EDL_PASSWORD=
```

And run the full test, you will see both the Pulling image from the `test-in-bamboo.sh` script
And also output from run_notebooks.sh

``` shell
./run_notebooks.sh
Running regression tests
Test suite harmony starting
running test with ghcr.io/nasa/regression-tests-harmony:0.1.3
Test suite harmony-regression starting
```



## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ N/A ] Tests added/updated (if needed) and passing
* [ N/A ] Documentation updated (if needed)