### PR TITLE
DAS-1972: Attempts to clean up containers on kill signal.

### DIFF
--- a/test/run_notebooks.sh
+++ b/test/run_notebooks.sh
@@ -61,6 +61,7 @@ function ctrl_c() {
     name_pid=(${name_comma_pid//,/ })
     echo "Killing ${name_pid[0]}"
     docker kill "${name_pid[1]}" >/dev/null
+    docker rm "${name_pid[1]}" >/dev/null
   done
   echo "Exiting"
   exit 1


### PR DESCRIPTION
-------

## Description

added a docker rm to the ctrl_c function

## Jira Issue ID

DAS-1972 is not directly related, but what I was working on when I found this.


## Local Test Steps

check out main.

Run a notebook and kill it before it completes.

> ./run_notebooks.sh hag

Interrupt with ctrl-c.

Examine the containers in your docker desktop.  You should see some exited containers.

Next check out this branch, and follow the same steps, you should no longer see exited containers.



## PR Acceptance Checklist
* [ n/a ] Acceptance criteria met
* [ n/a ] Tests added/updated (if needed) and passing
* [ n/a ] Documentation updated (if needed)