### PR TITLE
TRT-532 Add workflow to run regression test suite

### DIFF
--- a/.github/workflows/build-target-image.yml
+++ b/.github/workflows/build-target-image.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout regression test repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Did this image's version change?
         uses: dorny/paths-filter@v2

--- a/.github/workflows/run-target-test-suite.yml
+++ b/.github/workflows/run-target-test-suite.yml
@@ -1,0 +1,85 @@
+# This workflow runs a specific regression test suite, using the input image
+# name and tag from the workflow call.
+#
+# Required settings in the repository:
+# Environments (exactly the following strings):
+# - production
+# - uat
+# - sit
+#
+# Secrets in each environment:
+# - EDL_USER
+# - EDL_PASSWORD
+#
+# Variables in each environment:
+# - HARMONY_HOST_URL
+#
+# Note: A workflow_call event can only have inputs of type boolean, number or
+# string.
+name: Run test suite
+
+on:
+  workflow_call:
+    inputs:
+      docker-image-name:
+        required: true
+        type: string
+      docker-image-tag:
+        required: false
+        type: string
+        default: 'latest'
+      harmony-environment:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      docker-image-name:
+        required: true
+        type: choice
+        options:
+          - geoloco
+          - harmony-regression
+          - harmony
+          - hga
+          - hoss
+          - hybig
+          # - n2z  # Commented out because needs AWS credentials
+          - regridder
+          - swath-projector
+          - trajectory-subsetter
+          - variable-subsetter
+      docker-image-tag:
+        required: false
+        type: string
+        default: 'latest'
+      harmony-environment:
+        required: true
+        type: choice
+        options:
+          - sit
+          - uat
+          - production
+
+jobs:
+  run-tests:
+    environment: ${{ inputs.harmony-environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pull Docker image 
+        run: docker pull ghcr.io/nasa/regression-tests-${{ inputs.docker-image-name }}:${{ inputs.docker-image-tag }}
+      - name: Execute notebook
+        working-directory: ./test
+        env:
+          EDL_USER: ${{ secrets.EDL_USER }}
+          EDL_PASSWORD: ${{ secrets.EDL_PASSWORD }}
+          HARMONY_HOST_URL: ${{ vars.HARMONY_HOST_URL }}
+        run: ./run_notebooks.sh ${{ inputs.docker-image-name }}
+      - name: Save notebook as an artefact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: notebook-output
+          path: test/output/${{ inputs.docker-image-name }}/Results.ipynb

--- a/.github/workflows/run-target-test-suite.yml
+++ b/.github/workflows/run-target-test-suite.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Pull Docker image
         run: docker pull ghcr.io/nasa/regression-tests-${{ inputs.docker-image-name }}:${{ inputs.docker-image-tag }}
+
       - name: Execute notebook
         working-directory: ./test
         env:
@@ -77,6 +78,7 @@ jobs:
           EDL_PASSWORD: ${{ secrets.EDL_PASSWORD }}
           HARMONY_HOST_URL: ${{ vars.HARMONY_HOST_URL }}
         run: ./run_notebooks.sh ${{ inputs.docker-image-name }}
+
       - name: Save notebook as an artefact
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/run-target-test-suite.yml
+++ b/.github/workflows/run-target-test-suite.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Pull Docker image 
+      - name: Pull Docker image
         run: docker pull ghcr.io/nasa/regression-tests-${{ inputs.docker-image-name }}:${{ inputs.docker-image-tag }}
       - name: Execute notebook
         working-directory: ./test

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ locally in the browser against a single service regression test.
 * [Docker](https://www.docker.com/get-started) (to run locally in docker)
 
 
+## Running the Tests in GitHub:
+
+Each test suite can be individually invoked via a GitHub workflow. Navigate to
+the [GitHub Actions tab](https://github.com/nasa/harmony-regression-tests/actions)
+for this repository. Then select the "Run test suite" workflow from the lefthand
+menu. On the right hand side, click the "Run workflow" dropdown, and select the
+correct Docker image and Harmony environment. That should manually trigger the
+workflow.
+
 ## Running the Tests Locally
 
 Each test suite is run in a separate Docker container using a temporary Docker image


### PR DESCRIPTION
## Description

This PR adds a GitHub workflow that invokes a single regression test suite. The workflow can be triggered in two ways:

* Manually in the GitHub UI (see [here](https://github.com/owenlittlejohns/harmony-regression-tests/actions/runs/10291806978/job/28484900362) for an example of it running in my fork).
* When invoked by a different workflow.

My thinking is that this becomes a building block that other workflows would call, e.g.:

* A parent workflow with a `repository_dispatch` trigger to allow an external entity to invoke the tests (see [this blog](https://www.nieknijland.nl/blog/how-to-trigger-a-github-action-workflow-in-another-repository) for more information).
* A workflow that runs a specific workflow on a schedule (e.g., daily testing for NSIDC's short-term fix).

Things that need to change in this repository to make this work:

* In the Settings we need to add three environments: "production", "uat" and "sit".
* Under each environment we need to add 2 secrets:
  * EDL_USER
  * EDL_PASSWORD
* Under each environment we need to add 1 variable:
  * HARMONY_HOST_URL

Future work: Adding AWS credentials (which will need to be rotated), so the NetCDF-to-Zarr tests can be run.

## Jira Issue ID

TRT-532

## Local Test Steps

* Can check that it all worked in [this invocation](https://github.com/owenlittlejohns/harmony-regression-tests/actions/runs/10291806978/job/28484900362), though, from my local fork.
* To re-trigger:
  * Go to the [actions in my fork](https://github.com/owenlittlejohns/harmony-regression-tests/actions).
  * In the left menu of workflows select "Run test suite".
  * On the right, click on the dropdown to "Run workflow".
  * Select branch "TRT-532-add-regression-test-workflows".
  * Select an image name and Harmony environment.

(Let me know if you don't have enough permissions on the forked repository to run an action)

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* ~~Tests added/updated (if needed) and passing~~
* [x] Documentation updated (if needed) - ~~I should do this!~~