### PR TITLE
Pass input docker-image-tag to docker pull

### DIFF
--- a/.github/workflows/notebook-test-suite.yml
+++ b/.github/workflows/notebook-test-suite.yml
@@ -132,7 +132,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Pull Docker image
-        run: docker pull ghcr.io/nasa/regression-tests-${{ matrix.service }}:${{ github.event.client_payload.docker-image-tag || 'latest' }}
+        run: docker pull ghcr.io/nasa/regression-tests-${{ matrix.service }}:${{ github.event.client_payload.docker-image-tag || inputs.docker-image-tag || 'latest' }}
 
       - name: Execute notebook
         id: test-step


### PR DESCRIPTION
## Description

Fixes the ability to provide a regression image tag when running the a notebook test by hand

I was trying to test hybig in production and I wanted to specify the version of the regression to run, realized that it wasn't being picked up by github actions.


## Jira Issue ID

None

## Local Test Steps

You can fork and check your own repository, or you can look at this output. Check the command under pull docker image
https://github.com/flamingbear/harmony-regression-tests/actions/runs/11392069321/job/31697286308


```
Run docker pull ghcr.io/nasa/regression-tests-hybig:0.0.8
```



## PR Acceptance Checklist
* [N/A] Acceptance criteria met
* [N/A] Tests added/updated (if needed) and passing
* [N/A] Documentation updated (if needed)
* [N/A] CHANGELOG updated with the changes for this PR
