### PR TITLE
HARMONY-1933: Add harmony environment name to the harmony-regression-tests action name and notification.

### DIFF
--- a/.github/workflows/notebook-test-suite.yml
+++ b/.github/workflows/notebook-test-suite.yml
@@ -20,7 +20,7 @@
 # Note: A workflow_call event can only have inputs of type boolean, number or
 # string.
 name: Run Jupyter notebook based test suite
-run-name: ${{ github.event.action || inputs.service-name }} service regression tests
+run-name: ${{ github.event.action || inputs.service-name }} ${{ github.event.client_payload.harmony-environment || inputs.harmony-environment }} regression tests
 
 on:
   workflow_call:
@@ -171,7 +171,7 @@ jobs:
           server_port: 465
           username: ${{ secrets.SMTP_USER }}
           password: ${{ secrets.SMTP_PASSWORD }}
-          subject: ${{ github.event.action || inputs.service-name }} regression test result is ${{ needs.test.result }}
+          subject: ${{ github.event.action || inputs.service-name }} ${{ github.event.client_payload.harmony-environment || inputs.harmony-environment }} regression test result is ${{ needs.test.result }}
           to: ${{ env.TO_EMAIL }}
           from: ${{ secrets.FROM_EMAIL }}
-          body: ${{ github.event.action || inputs.service-name }} regression test result is ${{ needs.test.result }}! View the details at ${{ needs.test.outputs.run_url }}.
+          body: ${{ github.event.action || inputs.service-name }} ${{ github.event.client_payload.harmony-environment || inputs.harmony-environment }} regression test result is ${{ needs.test.result }}! View the details at ${{ needs.test.outputs.run_url }}.


### PR DESCRIPTION
## Description

Add harmony environment name to the harmony-regression-tests action name and notification. Below is the difference of the Action Name change between main and the PR branch.
![Screenshot 2024-10-29 at 4 06 03 PM](https://github.com/user-attachments/assets/022704ac-0b00-4638-b79b-c5e74631af22)

Email notification has similar changes.

## Jira Issue ID
HARMONY-1933

## Local Test Steps
Run Jupyter notebook based test suite manually to see the Action name and email notification changes, and they are more informative with the Harmony environment in them.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] CHANGELOG updated with the changes for this PR
