### PR TITLE
Add install and configuration commands for git-lfs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,14 @@ locally in the browser against a single service regression test.
 
 To work with this repository, ensure git-lfs (Git Large File Storage) is
 installed on your system, as it's used to manage some large files stored in
-GitHub.
+GitHub. To install git-lfs with Homebrew, enter the following commands:
+
+```
+brew install git-lfs
+git lfs install
+```
+
+If you have already cloned this repository, delete it and re-clone.
 
 
 ## Running the Tests in GitHub:


### PR DESCRIPTION
## Description

This PR adds a few lines to the README.md on how to configure Git LFS (Large File System). This is currently used for the reference files in the NSIDC ICESat-2 Trajectory Subsetter test notebook, but will (and should) likely be incorporated into other notebooks.

## Local Test Steps

Follow the new instructions in the README.md to configure Git LFS.

Execute the [NSIDC-ICESAT2_Regression.ipynb](https://github.com/nasa/harmony-regression-tests/blob/main/test/nsidc-icesat2/NSIDC-ICESAT2_Regression.ipynb) notebook. All tests should pass. 

Note 1: And indicator that Git LFS is correctly configured will be when the /nsidc-icesat2/reference_files have these sizes:

<img width="795" alt="image" src="https://github.com/user-attachments/assets/ad016517-095f-4971-989d-1e85e2c2e28c">


Note 2: If you haven't worked in this repository recently, you may have to re-create the nsidc-icesat2 conda environment used in the notebook.
