### PR TITLE
DAS-2254: Updates pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,10 +13,7 @@ repos:
     rev: v0.7.1
     hooks:
       - id: ruff
-        args: ["--fix", "--show-fixes"]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
-    hooks:
-      - id: black-jupyter
-        args: ["--skip-string-normalization"]
-        language_version: python3.11
+        args: ["--fix", "--show-fixes", "--extend-select", "I"]
+        types_or: [python, jupyter]
+      - id: ruff-format
+        types_or: [python, jupyter]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v0.7.1
     hooks:
       - id: ruff
-        args: ["--fix", "--show-fixes", "--extend-select", "I"]
+        args: ["--fix", "--show-fixes"]
         types_or: [python, jupyter]
       - id: ruff-format
         types_or: [python, jupyter]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ versioning. Rather than a static releases, this repository contains of a number
 of regression tests that are each semi-independent.  This CHANGELOG file should be used
 to document pull requests to this repository.
 
+## 2024-11-27([#119](https://github.com/nasa/harmony-regression-tests/pull/119))
+
+- Ensures proper formatting on all PRs.
+
 ## 2024-11-06 ([#112](https://github.com/nasa/harmony-regression-tests/pull/112))
 
 - Ensures conda packages are installed from conda-forge.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ For example, in the `swath-projector` directory we have
  Notebook dependencies should be listed in file named `environment.yaml` at the top level of the
  subdirectory. The `name` field in the file should be `papermill`. For example:
 
- ```yaml
+```yaml
 name: papermill-<IMAGE>
 channels:
   - conda-forge
@@ -315,9 +315,13 @@ checking the repository for some coding standard best practices. These include:
 * Removing trailing whitespaces.
 * Removing blank lines at the end of a file.
 * Ensure JSON files have valid formats.
-* [ruff](https://github.com/astral-sh/ruff) Python linting checks.
-* [black](https://black.readthedocs.io/en/stable/index.html) Python code
-  formatting checks.
+* Ensures large files aren't added to the repository
+* [ruff](https://github.com/astral-sh/ruff) to enforce:
+  + (pycodestyle): PEP 8 style guide enforcement (spacing, indentation, line length)
+  + (pyflakes): Logical errors like unused imports, undefined names, syntax errors
+  + (pyupgrade): Modernizes Python syntax (e.g., new string formats, type annotations)
+  + (isort): Import sorting and organization into sections
+  + single quotes style.
 
 To enable these checks:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,7 @@ lint.select = [
 
 [tool.ruff.format]
 quote-style = "single"
+
+# Override for long path names in Geoloco test notebook
+[tool.ruff.lint.per-file-ignores]
+"test/geoloco/Geoloco_Regression.ipynb" = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,12 @@ lint.select = [
   "E",   # (pycodestyle): PEP 8 style guide enforcement (spacing, indentation, line length)
   "F",   # (pyflakes): Logical errors like unused imports, undefined names, syntax errors
   "UP",  # (pyupgrade): Modernizes Python syntax (e.g., new string formats, type annotations)
-  "I",   # (isort): Import sorting and organization into sections
+  "I",   # (isort): Import sorting and organization into sections'
+  "D",   # (pydocstyle): Docstring
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.ruff.format]
 quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.ruff]
+lint.select = [
+  "E",   # (pycodestyle): PEP 8 style guide enforcement (spacing, indentation, line length)
+  "F",   # (pyflakes): Logical errors like unused imports, undefined names, syntax errors
+  "UP",  # (pyupgrade): Modernizes Python syntax (e.g., new string formats, type annotations)
+  "I",   # (isort): Import sorting and organization into sections
+]
+
+[tool.ruff.format]
+quote-style = "single"


### PR DESCRIPTION
# DAS-2254: Updates pre-commit configuration


## Description

This is just a quick change to remove a dependency on `black-pre-commit-mirror`
in the pre-commit hooks.

The changes configure `ruff` pre-commit for both python and jupyter files.

Adds pyproject.toml to control the ruff formatting options.
The new options force single quotes and these:

``` shell
  "E",   # (pycodestyle): PEP 8 style guide enforcement (spacing, indentation, line length)
  "F",   # (pyflakes): Logical errors like unused imports, undefined names, syntax errors
  "UP",  # (pyupgrade): Modernizes Python syntax (e.g., new string formats, type annotations)
  "I",   # (isort): Import sorting and organization into sections
  "D",   # (pydocstyle): Docstring formatting
```

-------

## Jira Issue ID

None really

## Local Test Steps

Pull this branch. Install the pre-commit changes.  

- fire up a Jupyter notebook 
- make some formating changes
- rearrange some imports
- swap some single quotes for doubles
- stage the changes and run the pre-commit hook.
- verify the changes put things back as expected


## PR Acceptance Checklist
* [N/A] Acceptance criteria met
* [N/A] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)
* [x] CHANGELOG updated with the changes for this PR
