### PR TITLE
DAS-2276: opera-rtc-s1-browse tests run with hybig deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ versioning. Rather than a static releases, this repository contains of a number
 of regression tests that are each semi-independent.  This CHANGELOG file should be used
 to document pull requests to this repository.
 
+## 2024-12-20([#126](https://github.com/nasa/harmony-regression-tests/pull/126))
+
+- Update configuration to run `opera-rtc-s1-browse` tests on HyBIG deployments.
+
 ## 2024-12-16 ([#122](https://github.com/nasa/harmony-regression-tests/pull/122))([#123](https://github.com/nasa/harmony-regression-tests/pull/123))
 
 - Updates HyBIG test images to account for changes in how HyBIG treats 3 and 4 band input GeoTIFFs.

--- a/config/services_tests_config_prod.json
+++ b/config/services_tests_config_prod.json
@@ -8,7 +8,7 @@
     "harmony-regridder": "regridder",
     "harmony-service-example": "harmony-regression",
     "hoss": "hoss",
-    "hybig": "hybig",
+    "hybig": "hybig,opera-rtc-s1-browse",
     "net2cog": "net2cog",
     "podaac-concise": "TBD",
     "podaac-l2-subsetter": "TBD",

--- a/config/services_tests_config_uat.json
+++ b/config/services_tests_config_uat.json
@@ -8,7 +8,7 @@
     "harmony-regridder": "regridder",
     "harmony-service-example": "harmony-regression",
     "hoss": "hoss, variable-subsetter",
-    "hybig": "hybig",
+    "hybig": "hybig,opera-rtc-s1-browse",
     "net2cog": "net2cog",
     "podaac-concise": "TBD",
     "podaac-l2-subsetter": "TBD",


### PR DESCRIPTION
## Description

opera-rtc-s1-browse depends on HyBIG, so we should run the tests when HyBIG is deployed.

## Jira Issue ID

[DAS-2276 sort of](https://bugs.earthdata.nasa.gov/browse/DAS-2276)


## Local Test Steps

Trust?  wait until HyBIG is deployed again and see that opera tests are included? 


## PR Acceptance Checklist
* [n/a] Acceptance criteria met
* [n/a] Tests added/updated (if needed) and passing
* [n/a] Documentation updated (if needed)
* [x] CHANGELOG updated with the changes for this PR
