### PR TITLE
TRT-680: Add CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Global code owners of the repository:
+# (Approval from a user/group is required to merge into main)
+*       @flamingbear @owenlittlejohns @nasa/harmony-admins


### PR DESCRIPTION
## Description

This PR adds a `CODEOWNERS` file. These will be default reviewers, with at least one approval from the listed reviewers needed to merge in to `main`.

## Jira Issue ID

N/A (TRT-680 is related, as making sure we don't add `git lfs` artefacts back to the repo was the motivation here)

## Local Test Steps

Check this file looks right, per the [documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~
* ~~CHANGELOG updated with the changes for this PR~~
* ~~Service's `version.txt` file changed if appropriate~~