### PR TITLE
TRT-680: Add warning to HGA test suite.

### DIFF
--- a/test/hga/HGA_Regression.ipynb
+++ b/test/hga/HGA_Regression.ipynb
@@ -5,6 +5,10 @@
    "id": "3fba6e94",
    "metadata": {},
    "source": [
+    "# Warning:\n",
+    "\n",
+    "This service is largely unused, and will be rescoped in the future. As such, both the service and this test suite are somewhat outdated and brittle. These tests should be tidied up as changes occur to HGA to reflect the new scope and capabilities of the service. Initial changes will likely include the removal of browse image generation and netCDF4 handling.\n",
+    "\n",
     "# Harmony GDAL Adapter (HGA) regression tests\n",
     "\n",
     "The scope of this Jupyter notebook is to run a suite of regression tests against sample collections for the Harmony GDAL Adapter (HGA). These sample collections are primarily from the Alaska Satellite Facility (ASF), including:\n",
@@ -2020,7 +2024,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.20"
+   "version": "3.10.13"
   },
   "name": "HGA_Regression.ipynb"
  },


### PR DESCRIPTION
## Description

This PR adds a warning to the HGA test suite. It doesn't need to be released.

I was going to convert the tests over to use `earthdata-hashdiff`, but that package requires Python 3.11 or higher, whilst the current version of GDAL used by the tests needs 3.10 or lower. Changing the version of GDAL breaks some of the tests (they no longer work with some of the output projections).

For a service that is basically unused in production, and will either be decommissioned or drastically descoped in the future, the warning added should be sufficient for now.

## Jira Issue ID

N/A

## Local Test Steps

N/A

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~
* ~~CHANGELOG updated with the changes for this PR~~
* ~~Service's `version.txt` file changed if appropriate~~
* ~~Original file is uploaded to S3 if references are changed~~