### PR TITLE
Ensure Docker containers use python3 kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ versioning. Rather than a static releases, this repository contains of a number
 of regression tests that are each semi-independent.  This CHANGELOG file should be used
 to document pull requests to this repository.
 
-## 2026-07-07 ([#](https://github.com/nasa/harmony-regression-tests/pull/))
+## 2026-07-07 ([#300](https://github.com/nasa/harmony-regression-tests/pull/300))
 
 ### Changed
 
-- Forces the notebook-entrypoint's papermill call to use the python3 kernel.
-  This allows the docker test containers to run irrespective of the notebook
-  metadata.
+- Updates notebook-entrypoint.sh to ensure the correct python kernel is used
+  when running the docker container tests. Fixes #121
 
 ## 2026-06-24 ([#297](https://github.com/nasa/harmony-regression-tests/pull/297))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versioning. Rather than a static releases, this repository contains of a number
 of regression tests that are each semi-independent.  This CHANGELOG file should be used
 to document pull requests to this repository.
 
+## 2026-07-07 ([#](https://github.com/nasa/harmony-regression-tests/pull/))
+
+### Changed
+
+- Forces the notebook-entrypoint's papermill call to use the python3 kernel.
+  This allows the docker test containers to run irrespective of the notebook
+  metadata.
+
 ## 2026-06-24 ([#297](https://github.com/nasa/harmony-regression-tests/pull/297))
 
 ### Changed

--- a/test/notebook-entrypoint.sh
+++ b/test/notebook-entrypoint.sh
@@ -9,4 +9,4 @@ mkdir -p /workdir/output/${env_sub_dir}
 
 export NETRC=/workdir/.netrc
 
-papermill --cwd ${env_sub_dir} ${env_sub_dir}/${env_notebook} /workdir/output/${env_sub_dir}/Results.ipynb -p harmony_host_url $harmony_host_url
+papermill --cwd ${env_sub_dir} ${env_sub_dir}/${env_notebook} /workdir/output/${env_sub_dir}/Results.ipynb -p harmony_host_url $harmony_host_url -k python3


### PR DESCRIPTION
## Description

Adds -k parameter to the papermill call to ensure python3 kernel is executed
during test runs in the docker containers.

## Jira Issue ID

Fixes #121


## Local Test Steps

The best way to test this would be to check out 1ea68c748124da61aed5fd4bcd04a1c261dc4fa8 from the #299 PR.

Build either the nsidc-smap or nsidc-icesat2 images and try to run the tests. 

You will get an error that the jupyter client can't find the kernel that is listed in the notebooks' metadata.

``` shell
raise NoSuchKernel(kernel_name)
jupyter_client.kernelspec.NoSuchKernel: No such kernel named papermill-nsidc-icesat2
Test suite nsidc-icesat2 failed with exit code 1
Tests completed (failed)
```

Apply the changes from this PR in the notebook-entry.sh and re-run.

``` diff
-papermill --cwd ${env_sub_dir} ${env_sub_dir}/${env_notebook} /workdir/output/${env_sub_dir}/Results.ipynb -p harmony_host_url $harmony_host_url
+papermill --cwd ${env_sub_dir} ${env_sub_dir}/${env_notebook} /workdir/output/${env_sub_dir}/Results.ipynb -p harmony_host_url $harmony_host_url -k python3

```



## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~
* [X] CHANGELOG updated with the changes for this PR
* [ ] ~Service's `version.txt` file changed if appropriate~
* [ ] ~Original file is uploaded to S3 if references are changed~
