### PR TITLE
HARMONY-2340: Add email notification for test suite maintainers

### DIFF
--- a/.github/workflows/notebook-test-suite.yml
+++ b/.github/workflows/notebook-test-suite.yml
@@ -192,6 +192,17 @@ jobs:
           HARMONY_HOST_URL: ${{ needs.base.outputs.harmony_host_url }}
         run: ./run_notebooks.sh ${{ matrix.service }}
 
+      - name: Record failed suite
+        if: always() && steps.test-step.outcome == 'failure'
+        run: echo "${{ matrix.service }}" > failed-suite-${{ matrix.service }}.txt
+
+      - name: Save failed suite as an artifact
+        if: always() && steps.test-step.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-suite-${{ matrix.service }}
+          path: failed-suite-${{ matrix.service }}.txt
+
       - name: Save notebook as an artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -205,13 +216,57 @@ jobs:
     environment: ${{ github.event.client_payload.harmony-environment || inputs.harmony-environment }}
     runs-on: ubuntu-latest
     steps:
+      - name: Download failed suite artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: failed-suite-*
+          path: failed-suites
+          merge-multiple: true
+          if-no-files-found: ignore
+
       - name: Get TO_EMAIL
         run: |
-          SERVICE_EMAILS=$(echo '${{ vars.SERVICES_EMAILS_CONFIG }}' | jq -r '."${{ github.event.action || inputs.service-name }}"')
-          if [ "$SERVICE_EMAILS" == "null" ]; then
-            SERVICE_EMAILS=${{ vars.TO_EMAIL_DEFAULT }}
+          SERVICE_NAME="${{ github.event.action || inputs.service-name }}"
+          SERVICE_EMAILS=$(echo '${{ vars.SERVICES_EMAILS_CONFIG }}' | jq -r --arg service "$SERVICE_NAME" '.[$service] // empty')
+          if [ -z "$SERVICE_EMAILS" ]; then
+            SERVICE_EMAILS='${{ vars.TO_EMAIL_DEFAULT }}'
           fi
-          echo "TO_EMAIL=$SERVICE_EMAILS" >> $GITHUB_ENV
+
+          ALL_EMAILS="$SERVICE_EMAILS"
+          FAILED_SUITES_LIST=""
+
+          if [ -d failed-suites ]; then
+            for file in failed-suites/*.txt; do
+              [ -e "$file" ] || continue
+              FAILED_SUITE=$(awk '{$1=$1;print}' "$file")
+              if [ -n "$FAILED_SUITE" ]; then
+                if [ -n "$FAILED_SUITES_LIST" ]; then
+                  FAILED_SUITES_LIST="$FAILED_SUITES_LIST,$FAILED_SUITE"
+                else
+                  FAILED_SUITES_LIST="$FAILED_SUITE"
+                fi
+              fi
+              FAILED_SUITE_EMAILS=$(echo '${{ vars.SERVICES_EMAILS_CONFIG }}' | jq -r --arg service "$FAILED_SUITE" '.[$service] // empty')
+              if [ -n "$FAILED_SUITE_EMAILS" ]; then
+                ALL_EMAILS="$ALL_EMAILS,$FAILED_SUITE_EMAILS"
+              fi
+            done
+          fi
+
+          TO_EMAIL=$(echo "$ALL_EMAILS" | tr ',' '\n' | awk '{$1=$1; if (length) print tolower($0)}' | awk '!seen[$0]++' | paste -sd, -)
+          echo "TO_EMAIL=$TO_EMAIL" >> $GITHUB_ENV
+          FAILED_SUITES_LIST=$(echo "$FAILED_SUITES_LIST" | tr ',' '\n' | awk '{$1=$1; if (length) print tolower($0)}' | awk '!seen[$0]++' | sort | paste -sd, -)
+          if [ -z "$FAILED_SUITES_LIST" ]; then
+            FAILED_SUITES_LIST="none"
+          fi
+          echo "FAILED_SUITES=$FAILED_SUITES_LIST" >> $GITHUB_ENV
+          if [ "$FAILED_SUITES_LIST" = "none" ]; then
+            echo "FAILED_SUITES_SUBJECT_SUFFIX=" >> $GITHUB_ENV
+            echo "FAILED_SUITES_BODY_LINE=" >> $GITHUB_ENV
+          else
+            echo "FAILED_SUITES_SUBJECT_SUFFIX= (failed suites: $FAILED_SUITES_LIST)" >> $GITHUB_ENV
+            echo "FAILED_SUITES_BODY_LINE= Failed suites: $FAILED_SUITES_LIST." >> $GITHUB_ENV
+          fi
 
       - name: Send mail
         uses: dawidd6/action-send-mail@v3
@@ -220,7 +275,16 @@ jobs:
           server_port: 465
           username: ${{ secrets.SMTP_USER }}
           password: ${{ secrets.SMTP_PASSWORD }}
-          subject: ${{ github.event.action || inputs.service-name }} ${{ github.event.client_payload.harmony-environment || inputs.harmony-environment }} regression test result is ${{ needs.test.result }}
+          subject: >-
+            ${{ github.event.action || inputs.service-name }}
+            ${{ github.event.client_payload.harmony-environment || inputs.harmony-environment }}
+            regression test result is ${{ needs.test.result }}
+            ${{ env.FAILED_SUITES_SUBJECT_SUFFIX }}
           to: ${{ env.TO_EMAIL }}
           from: ${{ secrets.FROM_EMAIL }}
-          body: ${{ github.event.action || inputs.service-name }} ${{ github.event.client_payload.harmony-environment || inputs.harmony-environment }} regression test result is ${{ needs.test.result }}! View the details at ${{ needs.test.outputs.run_url }}.
+          body: >-
+            ${{ github.event.action || inputs.service-name }}
+            ${{ github.event.client_payload.harmony-environment || inputs.harmony-environment }}
+            regression test result is ${{ needs.test.result }}!
+            ${{ env.FAILED_SUITES_BODY_LINE }}
+            View the details at ${{ needs.test.outputs.run_url }}.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ versioning. Rather than a static releases, this repository contains of a number
 of regression tests that are each semi-independent.  This CHANGELOG file should be used
 to document pull requests to this repository.
 
+## 2026-07-15 ([#302](https://github.com/nasa/harmony-regression-tests/pull/302/))
+
+### Changed
+
+- Add email notification to test suite maintainers on test failures in regression test.
+
 ## 2026-07-07 ([#299](https://github.com/nasa/harmony-regression-tests/pull/299/))
 
 ### Changed


### PR DESCRIPTION
## Description

In additional to sending email notification to service maintainers, also send email notification to test suite maintainers when the test suite fails during a service regression test. To achieve this, the harmony-regression-tests admin will add the notification emails for each test suite that wants notification on test failures.

For example, for the `net2cog` service as it is configured now with `net2cog,nsidc-smap,imagenator` test suites. The SERVICES_EMAILS_CONFIG would have the following configuration:
```
{
"net2cog": "net2cog@nasa.gov",
"nsidc-smap": "nsidc-smap@nasa.gov",
"imagenator": "imagenator@nasa.gov",
}
```
So that if the `nsidc-smap` test suite fails, the `nsidc-smap@nasa.gov"` email will get notified with the relevant regression test result; otherwise only the `net2cog@nasa.gov` email will get the successful regression test notification.

## Jira Issue ID
HARMONY-2340

## Local Test Steps
I have forked harmony-regression-tests in my own github repo and tested there. 
For successful case, see: https://github.com/ygliuvt/harmony-regression-tests/actions/runs/29418163788
For failure case, see: https://github.com/ygliuvt/harmony-regression-tests/actions/runs/29416849217

You can see the email recipients and body in the workflow log of the `email` step.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [x] CHANGELOG updated with the changes for this PR
* [ ] Service's `version.txt` file changed if appropriate
* [ ] Original file is uploaded to S3 if references are changed
