### PR TITLE
HARMONY-2392: Add GitHub workflows to validate image tags in environments

### DIFF
--- a/.github/workflows/validate-regression-image-tag-manual.yml
+++ b/.github/workflows/validate-regression-image-tag-manual.yml
@@ -1,0 +1,152 @@
+name: Validate regression image tag (manual)
+run-name: Validate regression image tag - ${{ github.event.inputs.harmony-environment }} ${{ github.event.inputs.test-suite }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      harmony-environment:
+        description: "Select the Harmony environment to run the validation in"
+        required: true
+        type: choice
+        options:
+          - uat
+          - prod
+      test-suite:
+        description: "Select the regression test suite to validate"
+        required: true
+        type: choice
+        options:
+          - all
+          - casper
+          - geoloco
+          - giovanni-averaging-service
+          - giovanni-time-series-adapter
+          - hga
+          - harmony
+          - harmony-flow
+          - harmony-regression
+          - hoss
+          - hybig
+          - imagenator
+          - net2cog
+          - nisar-py
+          - nsidc-icesat2
+          - nsidc-smap
+          - opera-rtc-s1-browse
+          - podaac-l2-subsetter
+          - regridder
+          - sambah
+          - smap-l2-gridder
+          - subset-band-name
+          - swath-projector
+          - trajectory-subsetter
+          - variable-subsetter
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      suites: ${{ steps.get-suites.outputs.suites }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: get-suites
+        run: |
+          SELECTED="${{ github.event.inputs.test-suite }}"
+          if [ "$SELECTED" = "all" ]; then
+            # Extract only the filename from the workflow reference (e.g., validate.yml)
+            WORKFLOW_FILENAME=$(basename "${GITHUB_WORKFLOW_REF%%@*}")
+            WORKFLOW_FILE=".github/workflows/$WORKFLOW_FILENAME"
+
+            # Use modern yq syntax to output single-line JSON array
+            SUITES=$(yq eval '.on.workflow_dispatch.inputs.test-suite.options | del(.[] | select(. == "all"))' "$WORKFLOW_FILE" -o=json -I=0)
+            echo "suites=$SUITES" >> "$GITHUB_OUTPUT"
+          else
+            echo "suites=[\"$SELECTED\"]" >> "$GITHUB_OUTPUT"
+          fi
+
+  validate:
+    needs: setup
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.harmony-environment }}
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJSON(needs.setup.outputs.suites) }}
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Validate required regression image tag for a single suite
+        id: validate
+        env:
+          SECRET_HARMONY_TOKEN: ${{ secrets.HARMONY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SECRET_HARMONY_TOKEN:-}" ]]; then
+            echo "HARMONY_TOKEN secret is required for environment '${{ github.event.inputs.harmony-environment }}'" >&2
+            exit 1
+          fi
+
+          case "${{ github.event.inputs.harmony-environment }}" in
+            uat)
+              harmony_host_url="https://harmony.uat.earthdata.nasa.gov"
+              ;;
+            prod)
+              harmony_host_url="https://harmony.earthdata.nasa.gov"
+              ;;
+            *)
+              echo "Invalid harmony environment '${{ github.event.inputs.harmony-environment }}'" >&2
+              exit 1
+              ;;
+          esac
+
+          suite="${{ matrix.suite }}"
+          if [[ -z "$suite" ]]; then
+            echo "suite is required" >&2
+            exit 1
+          fi
+
+          configuration_file="./config/services_tests_config_${{ github.event.inputs.harmony-environment }}.json"
+          if [[ ! -f "$configuration_file" ]]; then
+            echo "Configuration file not found: $configuration_file" >&2
+            exit 1
+          fi
+
+          source ./script/compute-regression-image-tag.sh
+          prefetch_service_image_tags "$harmony_host_url"
+
+          computed_tag="$(compute_regression_image_tag "$suite" "$harmony_host_url")"
+          image="ghcr.io/${{ github.repository_owner }}/regression-tests-${suite}:${computed_tag}"
+
+          echo "computed_tag=$computed_tag" >> "$GITHUB_OUTPUT"
+
+          if docker manifest inspect "$image" >/dev/null 2>&1; then
+            echo "Found required tag for ${suite}: ${computed_tag}"
+            echo "has_missing=false" >> "$GITHUB_OUTPUT"
+            echo "missing_count=0" >> "$GITHUB_OUTPUT"
+            echo "missing_suites=none" >> "$GITHUB_OUTPUT"
+          else
+            echo "Missing required tag for ${suite}: ${computed_tag}"
+            echo "has_missing=true" >> "$GITHUB_OUTPUT"
+            echo "missing_count=1" >> "$GITHUB_OUTPUT"
+            echo "missing_suites=${suite}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Log missing-tag status and fail step
+        if: steps.validate.outputs.has_missing == 'true'
+        env:
+          HARMONY_ENVIRONMENT: ${{ github.event.inputs.harmony-environment }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          echo "Validation failed for suite '${{ matrix.suite }}' in $HARMONY_ENVIRONMENT"
+          echo "Missing image tag: ghcr.io/${{ github.repository_owner }}/regression-tests-${{ matrix.suite }}:${{ steps.validate.outputs.computed_tag }}"
+          echo "Workflow run: $RUN_URL"
+          echo "You can add the tag to the desired image version by running:"
+          echo "  ./script/add-ghcr-tag.sh ghcr.io/${{ github.repository_owner }}/regression-tests-${{ matrix.suite }}:<version> ${{ steps.validate.outputs.computed_tag }}"
+          exit 1

--- a/.github/workflows/validate-regression-image-tag-manual.yml
+++ b/.github/workflows/validate-regression-image-tag-manual.yml
@@ -1,3 +1,14 @@
+# This workflow validates the regression test images are correctly tagged for the specified test suite
+# in a Harmony environment on demand. Pick `all` as the test suite name will validate the image tags
+# for all test suites.
+#
+# Required repository settings in each environment (uat, prod):
+# Secrets:
+# - HARMONY_TOKEN
+# Variables:
+# - SERVICES_EMAILS_CONFIG
+# - TO_EMAIL_DEFAULT
+
 name: Validate regression image tag (manual)
 run-name: Validate regression image tag - ${{ github.event.inputs.harmony-environment }} ${{ github.event.inputs.test-suite }}
 

--- a/.github/workflows/validate-regression-image-tags.yml
+++ b/.github/workflows/validate-regression-image-tags.yml
@@ -1,0 +1,221 @@
+# This workflow validates that each configured regression test suite has an
+# image tag matching currently deployed Harmony service versions.
+#
+# Required repository settings in each environment (uat, prod):
+# Secrets:
+# - HARMONY_TOKEN
+# - SMTP_USER
+# - SMTP_PASSWORD
+# - FROM_EMAIL
+# Variables:
+# - SERVICES_EMAILS_CONFIG
+# - TO_EMAIL_DEFAULT
+
+name: Validate regression image tags
+run-name: Validate regression image tags
+
+on:
+  schedule:
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        harmony-environment:
+          - uat
+          - prod
+    environment: ${{ matrix.harmony-environment }}
+
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Validate required regression image tags
+        id: validate
+        env:
+          HARMONY_TOKEN: ${{ secrets.HARMONY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${HARMONY_TOKEN:-}" ]]; then
+            echo "HARMONY_TOKEN secret is required for environment '${{ matrix.harmony-environment }}'" >&2
+            exit 1
+          fi
+
+          case "${{ matrix.harmony-environment }}" in
+            uat)
+              harmony_host_url="https://harmony.uat.earthdata.nasa.gov"
+              ;;
+            prod)
+              harmony_host_url="https://harmony.earthdata.nasa.gov"
+              ;;
+            *)
+              echo "Invalid harmony environment '${{ matrix.harmony-environment }}'" >&2
+              exit 1
+              ;;
+          esac
+
+          configuration_file="./config/services_tests_config_${{ matrix.harmony-environment }}.json"
+          if [[ ! -f "$configuration_file" ]]; then
+            echo "Configuration file not found: $configuration_file" >&2
+            exit 1
+          fi
+
+          source ./script/compute-regression-image-tag.sh
+          prefetch_service_image_tags "$harmony_host_url"
+
+          IFS=',' read -r -a suites <<< "$(jq -r '.all' "$configuration_file")"
+
+          missing_file="missing-tags-${{ matrix.harmony-environment }}.txt"
+          : > "$missing_file"
+
+          missing_count=0
+          for suite in "${suites[@]}"; do
+            suite="$(echo "$suite" | awk '{$1=$1;print}')"
+            [[ -z "$suite" ]] && continue
+
+            computed_tag="$(compute_regression_image_tag "$suite" "$harmony_host_url")"
+            image="ghcr.io/${{ github.repository_owner }}/regression-tests-${suite}:${computed_tag}"
+
+            if docker manifest inspect "$image" >/dev/null 2>&1; then
+              echo "Found required tag for ${suite}: ${computed_tag}"
+            else
+              echo "Missing required tag for ${suite}: ${computed_tag}"
+              echo "${suite}:${computed_tag}" >> "$missing_file"
+              missing_count=$((missing_count + 1))
+            fi
+          done
+
+          if [[ "$missing_count" -gt 0 ]]; then
+            missing_suites="$(cut -d: -f1 "$missing_file" | awk '!seen[$0]++' | paste -sd, -)"
+            echo "has_missing=true" >> "$GITHUB_OUTPUT"
+            echo "missing_count=$missing_count" >> "$GITHUB_OUTPUT"
+            echo "missing_suites=$missing_suites" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_missing=false" >> "$GITHUB_OUTPUT"
+            echo "missing_count=0" >> "$GITHUB_OUTPUT"
+            echo "missing_suites=none" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload missing tag report
+        if: always() && steps.validate.outputs.has_missing == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: missing-regression-image-tags-${{ matrix.harmony-environment }}
+          path: missing-tags-${{ matrix.harmony-environment }}.txt
+
+      - name: Send personalized missing-tag emails
+        if: steps.validate.outputs.has_missing == 'true'
+        env:
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          FROM_EMAIL: ${{ secrets.FROM_EMAIL }}
+          TO_EMAIL_DEFAULT: ${{ vars.TO_EMAIL_DEFAULT }}
+          SERVICES_EMAILS_CONFIG: ${{ vars.SERVICES_EMAILS_CONFIG }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          HARMONY_ENVIRONMENT: ${{ matrix.harmony-environment }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MISSING_FILE: missing-tags-${{ matrix.harmony-environment }}.txt
+        run: |
+          set -euo pipefail
+
+          python3 - <<'PY'
+          import json
+          import os
+          import smtplib
+          from email.message import EmailMessage
+
+          smtp_user = os.environ.get('SMTP_USER', '').strip()
+          smtp_password = os.environ.get('SMTP_PASSWORD', '').strip()
+          from_email = os.environ.get('FROM_EMAIL', '').strip()
+          to_email_default = os.environ.get('TO_EMAIL_DEFAULT', '').strip()
+          services_emails_config_raw = os.environ.get('SERVICES_EMAILS_CONFIG', '').strip()
+          repository_owner = os.environ.get('REPOSITORY_OWNER', '').strip()
+          harmony_environment = os.environ.get('HARMONY_ENVIRONMENT', '').strip()
+          run_url = os.environ.get('RUN_URL', '').strip()
+          missing_file = os.environ.get('MISSING_FILE', '').strip()
+
+          if not smtp_user or not smtp_password or not from_email:
+            raise SystemExit('SMTP_USER, SMTP_PASSWORD, and FROM_EMAIL must be set')
+          if not missing_file or not os.path.exists(missing_file):
+            raise SystemExit(f'Missing file not found: {missing_file}')
+
+          try:
+            services_emails_config = json.loads(services_emails_config_raw) if services_emails_config_raw else {}
+          except json.JSONDecodeError as exc:
+            raise SystemExit(f'SERVICES_EMAILS_CONFIG is not valid JSON: {exc}')
+
+          def normalize_recipients(raw_value):
+            if isinstance(raw_value, list):
+              candidates = raw_value
+            else:
+              candidates = str(raw_value or '').split(',')
+            unique = []
+            seen = set()
+            for item in candidates:
+              email = str(item).strip().lower()
+              if email and email not in seen:
+                unique.append(email)
+                seen.add(email)
+            return unique
+
+          sent_count = 0
+          with open(missing_file, 'r', encoding='utf-8') as handle:
+            lines = [line.strip() for line in handle if line.strip()]
+
+          if not lines:
+            print('No missing-tag lines found; no emails sent')
+            raise SystemExit(0)
+
+          with smtplib.SMTP_SSL('smtp.gmail.com', 465) as smtp:
+            smtp.login(smtp_user, smtp_password)
+
+            for line in lines:
+              suite, separator, computed_tag = line.partition(':')
+              suite = suite.strip()
+              computed_tag = computed_tag.strip()
+              if not suite or not separator or not computed_tag:
+                print(f'Skipping malformed missing-tag line: {line}')
+                continue
+
+              recipients = normalize_recipients(services_emails_config.get(suite, ''))
+              if not recipients and to_email_default:
+                recipients = normalize_recipients(to_email_default)
+              if not recipients:
+                print(f'No recipients available for suite {suite}; skipping email')
+                continue
+
+              image = f'ghcr.io/{repository_owner}/regression-tests-{suite}:{computed_tag}'
+
+              msg = EmailMessage()
+              msg['From'] = from_email
+              msg['To'] = ', '.join(recipients)
+              msg['Subject'] = f"Missing regression image tag [{harmony_environment}] {suite}"
+              msg.set_content(
+                f"A required regression image tag is missing for suite '{suite}' in {harmony_environment}.\n\n"
+                f"Missing image tag:\n"
+                f"- {image}\n\n"
+                f"Computed tag: {computed_tag}\n"
+                f"Environment: {harmony_environment}\n"
+                f"Workflow run: {run_url}\n"
+              )
+
+              smtp.send_message(msg)
+              sent_count += 1
+              print(f"Sent missing-tag email for suite '{suite}' to: {', '.join(recipients)}")
+
+          print(f'Sent {sent_count} personalized missing-tag email(s)')
+          PY
+
+      - name: Fail when required tags are missing
+        if: steps.validate.outputs.has_missing == 'true'
+        run: |
+          echo "Missing required regression image tags for ${{ matrix.harmony-environment }}: ${{ steps.validate.outputs.missing_suites }}" >&2
+          exit 1

--- a/.github/workflows/validate-regression-image-tags.yml
+++ b/.github/workflows/validate-regression-image-tags.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Validate required regression image tags
         id: validate
         env:
-          HARMONY_TOKEN: ${{ secrets.HARMONY_TOKEN }}
+          SECRET_HARMONY_TOKEN: ${{ secrets.HARMONY_TOKEN }}
         run: |
           set -euo pipefail
 
-          if [[ -z "${HARMONY_TOKEN:-}" ]]; then
+          if [[ -z "${SECRET_HARMONY_TOKEN:-}" ]]; then
             echo "HARMONY_TOKEN secret is required for environment '${{ matrix.harmony-environment }}'" >&2
             exit 1
           fi
@@ -202,9 +202,10 @@ jobs:
                 f"A required regression image tag is missing for suite '{suite}' in {harmony_environment}.\n\n"
                 f"Missing image tag:\n"
                 f"- {image}\n\n"
-                f"Computed tag: {computed_tag}\n"
                 f"Environment: {harmony_environment}\n"
                 f"Workflow run: {run_url}\n"
+                f"You can add the tag to the desired image version by running:\n"
+                f"  ./script/add-ghcr-tag.sh ghcr.io/{repository_owner}/regression-tests-{suite}:<version> {computed_tag}\n\n"
               )
 
               smtp.send_message(msg)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,25 @@ versioning. Rather than a static releases, this repository contains of a number
 of regression tests that are each semi-independent.  This CHANGELOG file should be used
 to document pull requests to this repository.
 
+## 2026-08-11 ([#312](https://github.com/nasa/harmony-regression-tests/pull/312))
+
+### Added
+
+- Add regression test image tag validation workflows
+
+
 ## 2026-08-07 ([#311](https://github.com/nasa/harmony-regression-tests/pull/311))
 
 ### Changed
 - Add harmony-flow to image build and regression test workflows
+
 
 ## 2026-08-05 ([#310](https://github.com/nasa/harmony-regression-tests/pull/310))
 
 ### Added
 
 - Added basic GUNW test cases to `net2cog` test.
+
 
 ## 2026-08-03 ([#309](https://github.com/nasa/harmony-regression-tests/pull/309))
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,43 @@ environment before installing from the environment.yml.
 1. Update the `harmony_host_url` in the notebook.
 1. Run the tests.
 
+
+## Tag regression test images
+
+Each regression test suite contains a services_tested.txt file that lists the services covered by the test suite. Service names are comma-delimited.
+
+The list of services in this file is used to compute the regression test image tag that identifies the exact set of service versions required by the test suite.
+
+For example, the sambah test suite has the following entry in services_tested.txt:
+```
+batchee,casper,podaac-concise,podaac-l2-subsetter,stitchee
+```
+Based on the service image versions currently deployed in PROD:
+```
+{
+  "batchee": "1.5.2",
+  "casper": "0.2.0",
+  "podaac-concise": "0.11.0",
+  "podaac-l2-subsetter": "3.3.2",
+  "stitchee": "1.9.0"
+}
+```
+The computed regression test image tag for the sambah test suite is:
+```
+batchee1.5.2_casper0.2.0_podaac-concise0.11.0_podaac-l2-subsetter3.3.2_stitchee1.9.0
+```
+This tag uniquely identifies the regression test image that contains the required service versions for that test suite. Service providers is responsible for tagging the regression test image once a new version of their service is deployed and tested with a regression test image or when a new version of the regression test image is built and tested.
+
+### Validate regression image tag workflows
+
+We provide two GitHub Actions workflows to validate that the computed regression test image tags exist for a given Harmony environment and test suite:
+
+- `validate-regression-image-tags.yml` — an automated workflow that validates computed regression image tags that runs daily and send tag validation failure emails to service providers to remind them to update their regression test image tag if it becomes obsolete due to new service versions deployed to Harmony.
+
+- `validate-regression-image-tag-manual.yml` — a manual workflow that can be run in the github Actions UI so maintainers can validate regression test images for all test suites or a specific test suite in a Harmony environment on demand.
+This manual workflow exposes a `test-suite` choice input in the workflow dispatch UI. Pick `all` will validate the image tags for all test suites; Pick a specific test suite will run validation for that test suite only.
+
+
 ## Adding a new test suite:
 
 1. Create a subdirectory within `test` that contains a notebook, environment,
@@ -178,7 +215,21 @@ file is updated. To do so, simply add a new target to the
 
     If no matching tagged image is found at runtime, the image specified in `version.txt` will be used as a fallback. Test suite maintainers will get email notifications when a computed regression test image tag is missing in a Harmony environment.
 
-1. If you want to trigger your tests by hand on GitHub, add your test name to the list of the [notebook-test-suite.yml](https://github.com/nasa/harmony-regression-tests/blob/main/.github/workflows/notebook-test-suite.yml):
+1. If you want to manually trigger the test image validation for your test suite on GitHub, add your test suite name to the list of the [validate-regression-image-tag-manual.yml](https://github.com/nasa/harmony-regression-tests/blob/main/.github/workflows/validate-regression-image-tag-manual.yml):
+   ```yaml
+   on:
+     workflow_dispatch:
+       test-suite:
+       description: "Select the regression test suite to validate"
+         required: true
+         type: choice
+         options:
+           - all
+           - casper
+           - your-test-suite
+   ```
+
+1. If you want to manually trigger regression tests for your service on GitHub, add your service name to the list of the [notebook-test-suite.yml](https://github.com/nasa/harmony-regression-tests/blob/main/.github/workflows/notebook-test-suite.yml):
    ```yaml
    on:
      workflow_dispatch:
@@ -188,6 +239,7 @@ file is updated. To do so, simply add a new target to the
            - batchee
            - your-new-service
    ```
+
 1. Provide the Harmony team with an email address and Slack user that can be contacted if your test suite fails during an automated run either in GitHub or Bamboo. This can be added to the wiki page here: https://wiki.earthdata.nasa.gov/spaces/HARMONY/pages/474940034/Harmony+Regression+Tests+Points+of+Contact. Please also update this wiki page if either of these pieces of information need to be changed
 
 ## Test suite contents:


### PR DESCRIPTION
## Description

Add GitHub workflows to validate image tags in environments. Two new GitHub Actions workflows are added to validate that the computed regression test image tags exist for a given Harmony environment and test suite:

- `validate-regression-image-tags.yml` — an automated workflow that validates computed regression image tags that runs daily and send tag validation failure emails to service providers to remind them to update their regression test image tag if it becomes obsolete due to new service versions deployed to Harmony.

- `validate-regression-image-tag-manual.yml` — a manual workflow that can be run in the github Actions UI so maintainers can validate regression test images for all test suites or a specific test suite in a Harmony environment on demand. This manual workflow exposes a `test-suite` choice input in the workflow dispatch UI. Pick `all` will validate the image tags for all test suite; Pick a specific test suite will run validation for that test suite only.

## Jira Issue ID
HARMONY-2392

## Local Test Steps
I tested the new workflows in my fork. See:
https://github.com/ygliuvt/harmony-regression-tests/actions/runs/31595673715
https://github.com/ygliuvt/harmony-regression-tests/actions/runs/31605455265

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)
* [x] CHANGELOG updated with the changes for this PR
* [ ] Service's `version.txt` file changed if appropriate
* [ ] Original file is uploaded to S3 if references are changed
